### PR TITLE
Make eCAL compile on current Arch Linux.

### DIFF
--- a/app/mon/eCALMon/src/Widgets/Models/ProcessTreeItem.cpp
+++ b/app/mon/eCALMon/src/Widgets/Models/ProcessTreeItem.cpp
@@ -22,6 +22,7 @@
 #include <QColor>
 #include <QFont>
 
+#include <math.h>
 #include <cfloat>
 
 #include "ItemDataRoles.h"

--- a/samples/cpp/services/math_server/src/math_server.cpp
+++ b/samples/cpp/services/math_server/src/math_server.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <chrono>
 #include <thread>
+#include <math.h>
 #include <cfloat>
 
 #include "math.pb.h"


### PR DESCRIPTION
Hello Rex,

if we add these two #includes, eCAL compiles out of the box on Arch Linux. If these changes do not bother your target OS, I'd like to ask for a merge.

Best regards,

Tobias