### PR TITLE
Fix .appveyor.yml file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
 build_script:
   - mkdir _build
   - cd _build
-  - cmake .. -G "Visual Studio 16 2019" -A x64 -DBUILD_PY_BINDING=ON -DBUILD_SAMPLES=ON -DCMAKE_INSTALL_PREFIX=_install
+  - cmake .. -G "Visual Studio 16 2019" -A x64 -DBUILD_PY_BINDING=ON -DBUILD_SAMPLES=ON -DBUILD_DOCS=ON -DCMAKE_INSTALL_PREFIX=_install
   - cmake --build . --parallel --config Release
   - cmake --build . --target documentation_c
   - cmake --build . --target documentation_cpp


### PR DESCRIPTION
To build documentation for window platform switch on CMake option BUILD_DOCS.