### PR TITLE
eCAL_Sub_Receive new signatures (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1020,7 +1020,7 @@ int main(int argc, char **argv)
   while(eCAL_Ok())
   {
     // receive content with 100 ms timeout
-    rcv = eCAL_Sub_Receive(sub, &rcv_buf, ECAL_ALLOCATE_4ME, &time, 100);
+    rcv = eCAL_Sub_Receive_Alloc(sub, &rcv_buf, &time, 100);
     if(rcv > 0)
     {
       // print content

--- a/ecal/core/include/ecal/cimpl/ecal_core_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_core_cimpl.h
@@ -116,7 +116,7 @@ extern "C"
    *            long long time     = 0;
    *            int       time_out = 100;   // ms
    *            void*     buf      = NULL;
-   *            int       buf_len  = eCAL_Sub_Receive(subscriber_handle, &buf, ECAL_ALLOCATE_4ME, &time, timeout);
+   *            int       buf_len  = eCAL_Sub_Receive_Alloc(subscriber_handle, &buf, &time, timeout);
    *            if(buf_len > 0)
    *            {
    *              ...

--- a/ecal/core/include/ecal/cimpl/ecal_subscriber_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_subscriber_cimpl.h
@@ -95,7 +95,9 @@ extern "C"
   ECALC_API int eCAL_Sub_SetID(ECAL_HANDLE handle_, const long long* id_array_, const int id_num_);
   
   /**
-   * @brief Receive a message from the publisher. 
+   * @brief Receive a message from the publisher
+   *
+   * @deprecated  Use the eCAL_Sub_Receive_ToBuffer or eCAL_Sub_Receive_Alloc instead.
    *
    * @param       handle_       Subscriber handle. 
    * @param [out] buf_          Buffer to store the received message content.
@@ -107,6 +109,32 @@ extern "C"
    * @return  Length of received buffer. 
   **/
   ECALC_API int eCAL_Sub_Receive(ECAL_HANDLE handle_, void* buf_, int buf_len_, long long* time_, int rcv_timeout_);
+
+  /**
+   * @brief Receive a message from the publisher in a preallocated buffer.
+   *
+   * @param       handle_       Subscriber handle. 
+   * @param       buf_          Buffer to store the received message content.
+   * @param       buf_len_      Length of the receive buffer.
+   * @param [out] time_         Time from publisher in us.
+   * @param       rcv_timeout_  Maximum time before receive operation returns (in milliseconds, -1 means infinite).
+   *
+   * @return  Length of received buffer. 
+  **/
+  ECALC_API int eCAL_Sub_Receive_ToBuffer(ECAL_HANDLE handle_, void* buf_, int buf_len_, long long* time_, int rcv_timeout_);
+
+  /**
+   * @brief Receive a message from the publisher and let eCAL allocate the memory.
+   *
+   * @param       handle_       Subscriber handle. 
+   * @param [out] buf_          Buffer to store the pointer to the received message content.
+   *                            You need to free the memory finally calling eCAL_FreeMem.
+   * @param [out] time_         Time from publisher in us.
+   * @param       rcv_timeout_  Maximum time before receive operation returns (in milliseconds, -1 means infinite).
+   *
+   * @return  Length of received buffer. 
+  **/
+  ECALC_API int eCAL_Sub_Receive_Alloc(ECAL_HANDLE handle_, void** buf_, long long* time_, int rcv_timeout_);
 
   /**
    * @brief Add callback function for incoming receives. 

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -392,7 +392,7 @@ namespace eCAL
     {
       if(!m_subscriber) return(0);
       void* buf = nullptr;
-      size_t buf_len = eCAL_Sub_Receive(m_subscriber, &buf, ECAL_ALLOCATE_4ME, time_, rcv_timeout_);
+      size_t buf_len = eCAL_Sub_Receive_Alloc(m_subscriber, &buf, time_, rcv_timeout_);
       if(buf_len > 0)
       {
         buf_ = std::string(static_cast<char*>(buf), buf_len);

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -695,12 +695,38 @@ extern "C"
 
   ECALC_API int eCAL_Sub_Receive(ECAL_HANDLE handle_, void* buf_, int buf_len_, long long* time_, int rcv_timeout_)
   {
-    if(handle_ == NULL) return(0);
+    if (buf_len_ == ECAL_ALLOCATE_4ME)
+    {
+      return eCAL_Sub_Receive_Alloc(handle_, static_cast<void**>(buf_), time_, rcv_timeout_);
+    }
+    else
+    {
+      return eCAL_Sub_Receive_ToBuffer(handle_, buf_, buf_len_, time_, rcv_timeout_);
+    }
+  }
+
+  ECALC_API int eCAL_Sub_Receive_ToBuffer(ECAL_HANDLE handle_, void* buf_, int buf_len_, long long* time_, int rcv_timeout_)
+  {
+    if (handle_ == NULL) return(0);
     eCAL::CSubscriber* sub = static_cast<eCAL::CSubscriber*>(handle_);
+
     std::string buf;
-    if(sub->Receive(buf, time_, rcv_timeout_))
+    if (sub->Receive(buf, time_, rcv_timeout_))
     {
       return(CopyBuffer(buf_, buf_len_, buf));
+    }
+    return(0);
+  }
+
+  ECALC_API int eCAL_Sub_Receive_Alloc(ECAL_HANDLE handle_, void** buf_, long long* time_, int rcv_timeout_)
+  {
+    if (handle_ == NULL) return(0);
+    eCAL::CSubscriber* sub = static_cast<eCAL::CSubscriber*>(handle_);
+
+    std::string buf;
+    if (sub->Receive(buf, time_, rcv_timeout_))
+    {
+      return(CopyBuffer(buf_, ECAL_ALLOCATE_4ME, buf));
     }
     return(0);
   }

--- a/samples/c/minimal/minimal_rec/src/minimal_rec.c
+++ b/samples/c/minimal/minimal_rec/src/minimal_rec.c
@@ -22,10 +22,10 @@
 
 int main(int argc, char **argv)
 {
-  ECAL_HANDLE sub = 0;
-  int         rcv = 0;
-  void*       rcv_buf;
-  long long   time;
+  ECAL_HANDLE sub     = 0;
+  int         rcv     = 0;
+  void*       rcv_buf = NULL;
+  long long   time    = 0;
 
   // initialize eCAL API
   eCAL_Initialize(argc, argv, "minimalc_rec", eCAL_Init_Default);
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
   while(eCAL_Ok())
   {
     // receive content with 100 ms timeout
-    rcv = eCAL_Sub_Receive(sub, &rcv_buf, ECAL_ALLOCATE_4ME, &time, 100);
+    rcv = eCAL_Sub_Receive_Alloc(sub, &rcv_buf, &time, 100);
     if(rcv > 0)
     {
       // print content


### PR DESCRIPTION
2 new functions implemented 

```
int eCAL_Sub_Receive_ToBuffer(ECAL_HANDLE handle_, void* buf_, int buf_len_, long long* time_, int rcv_timeout_);
```

and 

```
int eCAL_Sub_Receive_Alloc(ECAL_HANDLE handle_, void** buf_, long long* time_, int rcv_timeout_); 
```

to replace the common eCAL_Sub_Receive (which is now deprecated). This should fix #51 