### PR TITLE
Feature/vs140 platform

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -65,7 +65,7 @@ jobs:
         mkdir "${{ runner.workspace }}\_build\sdk\"
         cd "${{ runner.workspace }}/_build/sdk"
         
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 ^
+        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v140 ^
         -DHAS_HDF5=ON ^
         -DHAS_QT5=ON ^
         -DHAS_CURL=ON ^

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -27,7 +27,7 @@ jobs:
 #        cd c++
 #        mkdir _build
 #        cd _build
-#        cmake .. -G "Visual Studio 16 2019" -A x64
+#        cmake .. -G "Visual Studio 16 2019" -A x64 -T v140
 #        cmake --build . --parallel --config Release
 #        cmake --build . --target install --config Release
 
@@ -100,7 +100,7 @@ jobs:
       run: |
         CALL "${{ runner.workspace }}\.venv\Scripts\activate.bat"
         cd "${{ runner.workspace }}/_build/complete"
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 ^
+        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v140 ^
         -DHAS_HDF5=ON ^
         -DHAS_QT5=ON ^
         -DHAS_CURL=ON ^


### PR DESCRIPTION
To ensure ABI downwards compatibility to VS2015 cmake is configured to use platform toolset v140.