### PR TITLE
Fix GitHub Actions Ubuntu18.04 libgcc1 / libgcc-s1 dependency issue

### DIFF
--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -14,8 +14,10 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
-        sudo apt-get -y purge g++-10 g++-9 g++-8 libgcc-10-dev libgcc-9-dev libgcc-8-dev libgcc-s1
+        sudo apt-get -y purge g++-10 g++-9 g++-8
+        
+# sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
+        
         
     - name: Install Cap’n Proto
       run: |

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -43,6 +43,8 @@ jobs:
 
     - name: CMake
       run: |
+        export CC=/usr/bin/gcc-7
+        export CXX=/usr/bin/g++-7
         mkdir "${{ runner.workspace }}/_build"
         cd "${{ runner.workspace }}/_build"
         cmake $GITHUB_WORKSPACE \

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -111,9 +111,9 @@ jobs:
       run: cmake --build . --target create_python_egg --config Release
       working-directory: ${{ runner.workspace }}/_build
 
-#    - name: Run Tests
-#      run: ctest -V
-#      working-directory: ${{ runner.workspace }}/_build
+    - name: Run Tests
+      run: ctest -V
+      working-directory: ${{ runner.workspace }}/_build
 
     - name: Pack
       run: cpack -G DEB

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -15,6 +15,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
+        sudo apt-get -y purge g++-10 g++-9 g++-8 libgcc-10-dev libgcc-9-dev libgcc-8-dev libgcc-s1
         
     - name: Install Cap’n Proto
       run: |

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -14,9 +14,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update
-        sudo apt-get -y purge g++-10 g++-9 g++-8
-        
-# sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
+        sudo apt-get -y purge g++-10 g++-9 g++-8 libgcc-10-dev libgcc-9-dev libgcc-8-dev
+        sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
         
         
     - name: Install Cap’n Proto

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -9,14 +9,23 @@ on:
 jobs:
   build-ubuntu:
     runs-on: ubuntu-18.04
+    
+    steps:
+    - name: Getting closer to vanilla Ubuntu 18.04
+      run: |
+        sudo apt-get -y update
+        sudo apt-get -y install ppa-purge
+        sudo ppa-purge -y ubuntu-toolchain-r/test
+        sudo apt-get -y install g++
+      shell: bash
 
     steps:
     - name: Install Dependencies
       run: |
-        sudo apt update
-        sudo apt-get -y purge g++-10 g++-9 g++-8 libgcc-10-dev libgcc-9-dev libgcc-8-dev
+        sudo apt-get -y update
         sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
-        
+      shell: bash
+
     - name: Install Cap’n Proto
       run: |
         mkdir "${{ runner.workspace }}/capnp"
@@ -85,14 +94,6 @@ jobs:
     - name: Build Python Egg
       run: cmake --build . --target create_python_egg --config Release
       working-directory: ${{ runner.workspace }}/_build
-
-#    - name: Build Documentation C
-#      run: cmake --build . --target documentation_c
-#      working-directory: ${{ runner.workspace }}/_build
-
-#    - name: Build Documentation C++
-#      run: cmake --build . --target documentation_cpp
-#      working-directory: ${{ runner.workspace }}/_build
 
 #    - name: Run Tests
 #      run: ctest -V

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -17,7 +17,6 @@ jobs:
         sudo apt-get -y purge g++-10 g++-9 g++-8 libgcc-10-dev libgcc-9-dev libgcc-8-dev
         sudo apt-get -y install cmake doxygen graphviz build-essential zlib1g-dev qt5-default libhdf5-dev libprotobuf-dev libprotoc-dev protobuf-compiler libcurl4-openssl-dev python3-setuptools
         
-        
     - name: Install Cap’n Proto
       run: |
         mkdir "${{ runner.workspace }}/capnp"
@@ -95,9 +94,9 @@ jobs:
 #      run: cmake --build . --target documentation_cpp
 #      working-directory: ${{ runner.workspace }}/_build
 
-    - name: Run Tests
-      run: ctest -V
-      working-directory: ${{ runner.workspace }}/_build
+#    - name: Run Tests
+#      run: ctest -V
+#      working-directory: ${{ runner.workspace }}/_build
 
     - name: Pack
       run: cpack -G DEB

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Getting closer to vanilla Ubuntu 18.04
       run: |
         sudo apt-get -y update
+        sudo apt-get -y install libgcc1
         sudo apt-get -y install ppa-purge
         sudo ppa-purge -y ubuntu-toolchain-r/test
         sudo apt-get -y install g++

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -14,10 +14,14 @@ jobs:
     - name: Getting closer to vanilla Ubuntu 18.04
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install libgcc1
+        mkdir libgcc1_deb
+        cd libgcc1_deb
+        apt-get download -t bionic-security libgcc1
         sudo apt-get -y install ppa-purge
         sudo ppa-purge -y ubuntu-toolchain-r/test
+        sudo dpkg -i libgcc1_deb/*
         sudo apt-get -y install g++
+        cd ..
       shell: bash
 
     - name: Install Dependencies

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -14,13 +14,25 @@ jobs:
     - name: Getting closer to vanilla Ubuntu 18.04
       run: |
         sudo apt-get -y update
+        
+        echo "Creating directory for libgcc1"
         mkdir libgcc1_deb
         cd libgcc1_deb
+        pwd
+        
+        echo "Downloading bionic-security libgcc1"
         apt-get download -t bionic-security libgcc1
+        
+        echo "Purging GH Actions toolchain PPA"
         sudo apt-get -y install ppa-purge
         sudo ppa-purge -y ubuntu-toolchain-r/test
-        sudo dpkg -i libgcc1_deb/*
+        
+        echo "installing libgcc1_deb"
+        sudo dpkg -i *
+        
+        echo "Installing g++"
         sudo apt-get -y install g++
+        
         cd ..
       shell: bash
 

--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -19,7 +19,6 @@ jobs:
         sudo apt-get -y install g++
       shell: bash
 
-    steps:
     - name: Install Dependencies
       run: |
         sudo apt-get -y update

--- a/.github/workflows/build-ubuntu-20.yml
+++ b/.github/workflows/build-ubuntu-20.yml
@@ -43,6 +43,8 @@ jobs:
 
     - name: CMake
       run: |
+        export CC=/usr/bin/gcc-9
+        export CXX=/usr/bin/g++-9
         mkdir "${{ runner.workspace }}/_build"
         cd "${{ runner.workspace }}/_build"
         cmake $GITHUB_WORKSPACE -G "Ninja" \

--- a/.github/workflows/build-ubuntu-20.yml
+++ b/.github/workflows/build-ubuntu-20.yml
@@ -85,14 +85,6 @@ jobs:
       run: cmake --build . --target create_python_egg --config Release
       working-directory: ${{ runner.workspace }}/_build
 
-#    - name: Build Documentation C
-#      run: cmake --build . --target documentation_c
-#      working-directory: ${{ runner.workspace }}/_build
-
-#    - name: Build Documentation C++
-#      run: cmake --build . --target documentation_cpp
-#      working-directory: ${{ runner.workspace }}/_build
-
     - name: Run Tests
       run: ctest -V
       working-directory: ${{ runner.workspace }}/_build


### PR DESCRIPTION
Downgraded GitHub Actions GCC/G++ Verisons on Ubuntu 18.04. Github Actions uses a PPA, which introduces libgcc-s1 as dependency. That package is not available by default on Ubuntu 18 (The package is called libgcc1)

The Solution is to
1. Download the official libgcc1
2. `ppa-purge` the ppa
3. Install the downloaded libgcc1 with dpkg (ppa-purge will brick the system, this will un-brick it again 😉)

Code:

``` bash
sudo apt-get -y update

echo "Creating directory for libgcc1"
mkdir libgcc1_deb
cd libgcc1_deb
pwd

echo "Downloading bionic-security libgcc1"
apt-get download -t bionic-security libgcc1

echo "Purging GH Actions toolchain PPA"
sudo apt-get -y install ppa-purge
sudo ppa-purge -y ubuntu-toolchain-r/test

echo "installing libgcc1_deb"
sudo dpkg -i *

echo "Installing g++"
sudo apt-get -y install g++

cd ..
```


