### PR TITLE
Multiarch support by using CMake Paths

### DIFF
--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -95,7 +95,11 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_CURL=OFF \
         -DECAL_THIRDPARTY_BUILD_GTEST=ON \
         -DECAL_THIRDPARTY_BUILD_HDF5=OFF \
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
         sudo mkdir /etc/ecal
         sudo cp "$GITHUB_WORKSPACE/ecal/core/cfg/ecal.ini" /etc/ecal
       shell: bash

--- a/.github/workflows/build-ubuntu-20.yml
+++ b/.github/workflows/build-ubuntu-20.yml
@@ -69,7 +69,11 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_CURL=OFF \
         -DECAL_THIRDPARTY_BUILD_GTEST=ON \
         -DECAL_THIRDPARTY_BUILD_HDF5=OFF \
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
         sudo mkdir /etc/ecal
         sudo cp "$GITHUB_WORKSPACE/ecal/core/cfg/ecal.ini" /etc/ecal
       shell: bash

--- a/.github/workflows/build-ubuntu-iceoryx.yml
+++ b/.github/workflows/build-ubuntu-iceoryx.yml
@@ -82,7 +82,11 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_GTEST=ON \
         -DECAL_THIRDPARTY_BUILD_HDF5=OFF \
         -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/iceoryx/iceoryx/build/install/prefix/lib/cmake/iceoryx_posh;${{ runner.workspace }}/iceoryx/iceoryx/build/install/prefix/lib/cmake/iceoryx_utils" \
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
+        -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
         sudo mkdir /etc/ecal
         sudo cp "$GITHUB_WORKSPACE/ecal/core/cfg/ecal.ini" /etc/ecal
       shell: bash

--- a/app/mon/mon_gui/src/plugin/plugin_manager.cpp
+++ b/app/mon/mon_gui/src/plugin/plugin_manager.cpp
@@ -28,6 +28,7 @@
 #include <QProcessEnvironment>
 
 #include <ecal/ecal_log.h>
+#include <ecal/ecal_defs.h>
 
 std::unique_ptr<PluginManager> PluginManager::instance_;
 

--- a/app/mon/mon_gui/src/plugin/plugin_manager.cpp
+++ b/app/mon/mon_gui/src/plugin/plugin_manager.cpp
@@ -53,22 +53,18 @@ QVector<QDir> GetPluginDirectories()
 
   // Specify the default plugin directory
   // On windows: cwd/ecalmon_plugins
-  // On Linux: ../lib/ecal/mon_plugins
-  auto default_plugin_dir = QDir(qApp->applicationDirPath());
+  // On Linux: ../lib/ecal/plugins/mon
+  QString default_plugin_dir = qApp->applicationDirPath();
 #ifdef Q_OS_WIN
-  default_plugin_dir.cd("ecalmon_plugins");
+  default_plugin_dir += QString("/ecalmon_plugins")
 #else
-  default_plugin_dir.cdUp();
-  default_plugin_dir.cd("lib");
-  default_plugin_dir.cd("ecal");
-  default_plugin_dir.cd("plugins");
-  default_plugin_dir.cd("mon");
+  default_plugin_dir += QString("/../lib/ecal/plugins/mon");
 #endif
-  plugin_directories.push_back(default_plugin_dir);
+  plugin_directories.push_back(QDir(default_plugin_dir));
 
   // Retrieve additional plugin directories through the environment varialbe "ECAL_MON_PLUGIN_PATH"
   auto current_environment = QProcessEnvironment::systemEnvironment();
-  auto additional_plugin_paths = current_environment.value("ECAL_MON_PLUGIN_PATH");
+  auto additional_plugin_paths   = current_environment.value("ECAL_MON_PLUGIN_PATH");
 
   if (!additional_plugin_paths.isEmpty())
   {
@@ -78,6 +74,26 @@ QVector<QDir> GetPluginDirectories()
       plugin_directories.push_back(QDir(path));
     }
   }
+
+#ifndef Q_OS_WIN
+  // Add the actually installed plugin directory (which may be a multiarch lib dir!)
+
+  QString installed_plugin_dir;
+
+  if (QString(ECAL_INSTALL_PREFIX).isEmpty()
+     || QString(ECAL_INSTALL_LIB_DIR).startsWith('/'))
+  {
+    // The Path is absolute or the prefix is empty anyways
+    installed_plugin_dir = QString(ECAL_INSTALL_LIB_DIR);
+  }
+  else
+  {
+    installed_plugin_dir = QString(ECAL_INSTALL_PREFIX) + QString("/") + QString(ECAL_INSTALL_LIB_DIR);
+  }
+  installed_plugin_dir += QString("/ecal/plugins/mon");
+
+  plugin_directories.push_back(QDir(installed_plugin_dir));
+#endif
 
   return plugin_directories;
 }

--- a/app/mon/mon_gui/src/plugin/plugin_manager.cpp
+++ b/app/mon/mon_gui/src/plugin/plugin_manager.cpp
@@ -56,7 +56,7 @@ QVector<QDir> GetPluginDirectories()
   // On Linux: ../lib/ecal/plugins/mon
   QString default_plugin_dir = qApp->applicationDirPath();
 #ifdef Q_OS_WIN
-  default_plugin_dir += QString("/ecalmon_plugins")
+  default_plugin_dir += QString("/ecalmon_plugins");
 #else
   default_plugin_dir += QString("/../lib/ecal/plugins/mon");
 #endif

--- a/app/rec/rec_client_core/src/addons/addon_manager.cpp
+++ b/app/rec/rec_client_core/src/addons/addon_manager.cpp
@@ -62,6 +62,29 @@ namespace eCAL
         EcalUtils::String::Split(std::string(additional_addon_dirs), dir_delimiter, addon_dirs);
       }
 
+#ifndef WIN32
+      // Add the actually installed plugin directory (which may be a multiarch lib dir!)
+
+      std::string installed_plugin_dir;
+
+      std::string ecal_install_prefix (ECAL_INSTALL_PREFIX);
+      std::string ecal_install_lib_dir(ECAL_INSTALL_LIB_DIR);
+
+      if (ecal_install_prefix.empty()
+         || (!ecal_install_lib_dir.empty() && (ecal_install_lib_dir.front() == EcalUtils::Filesystem::NativeSeparator())))
+      {
+        // The Path is absolute or the prefix is empty anyways
+        installed_plugin_dir = ecal_install_lib_dir;
+      }
+      else
+      {
+        installed_plugin_dir = ecal_install_prefix + EcalUtils::Filesystem::NativeSeparator() + ecal_install_lib_dir;
+      }
+      installed_plugin_dir += "/ecal/addons/rec";
+
+      addon_dirs.push_back(installed_plugin_dir);
+#endif
+
       return addon_dirs;
     }
 

--- a/app/rec/rec_client_core/src/addons/addon_manager.cpp
+++ b/app/rec/rec_client_core/src/addons/addon_manager.cpp
@@ -26,6 +26,8 @@
 
 #include <list>
 
+#include <ecal/ecal_defs.h>
+
 namespace eCAL
 {
   namespace rec

--- a/cpack/cpack_variables.cmake
+++ b/cpack/cpack_variables.cmake
@@ -29,7 +29,7 @@ SET(CPACK_OUTPUT_FILE_PREFIX _deploy)
   ##set(CPACK_WIX_PATCH_FILE ${CMAKE_SOURCE_DIR}/cpack/ecal_path.xml)
   ##set(CPACK_WIX_TEMPLATE   "${CMAKE_SOURCE_DIR}/cpack/custom_template.wxs.in")
   ##configure_file("${CMAKE_SOURCE_DIR}/cpack/custom_template.wxs.in" "${CMAKE_BINARY_DIR}/custom_template.wxi" #@ONLY)
-  
+
 #endif()
 if(WIN32)
   set(CPACK_GENERATOR "External")
@@ -43,6 +43,11 @@ endif()
 if(UNIX)
   set(CPACK_GENERATOR "DEB")
   set(CPACK_SOURCE_GENERATOR "TGZ")
+
+  # When configuring the project, a header file with paths has been created.
+  # These paths are used e.g. in eCAL Mon to find the plugin diretory. Thus we
+  # need to use the same paths for cpack.
+  set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 endif()
 
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
@@ -57,7 +62,7 @@ set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE.txt)
 set(CPACK_RESOURCE_FILE_README  ${CMAKE_SOURCE_DIR}/README.md)
 
 get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
-list(REMOVE_ITEM CPACK_COMPONENTS_ALL 
+list(REMOVE_ITEM CPACK_COMPONENTS_ALL
   #"libprotobuf-lite"
   #"protobuf-export"
   #"protobuf-headers"

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_defs.h>
 
 #include "ecal_def.h"
 #include "ecal_config.h"
@@ -150,10 +151,22 @@ namespace eCAL
 #endif /* ECAL_OS_WINDOWS */
 
 #ifdef ECAL_OS_LINUX
-      config_path = ECAL_USER_CONFIG_PATH_LINUX;
-      if (!direxists(config_path))
+      std::string ecal_install_config_dir(ECAL_INSTALL_CONFIG_DIR);
+      std::string ecal_install_prefix    (ECAL_INSTALL_PREFIX);
+
+      if ((!ecal_install_config_dir.empty() && (ecal_install_config_dir[0] == '/'))
+          || ecal_install_prefix.empty())
       {
-        config_path = ECAL_CONFIG_PATH_LINUX;
+        config_path = ecal_install_config_dir;
+      }
+      else if (!ecal_install_prefix.empty())
+      {
+        config_path = ecal_install_prefix + "/" + ecal_install_config_dir;
+      }
+
+      if (!config_path.empty() && (config_path.back() != '/'))
+      {
+        config_path += "/";
       }
 #endif /* ECAL_OS_LINUX */
 

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -31,8 +31,6 @@
 /* base data path name */
 #define ECAL_HOME_PATH_WINDOWS                     ""
 #define ECAL_HOME_PATH_LINUX                       ".ecal"
-#define ECAL_CONFIG_PATH_LINUX                     "/etc/ecal/"
-#define ECAL_USER_CONFIG_PATH_LINUX                "/usr/etc/ecal/"
 #define ECAL_LOG_PATH                              "logs"
 #define ECAL_SETTINGS_PATH                         "cfg"
 

--- a/ecal/core/src/ecal_defs.h.in
+++ b/ecal/core/src/ecal_defs.h.in
@@ -6,4 +6,12 @@
 #define ECAL_VERSION "@GIT_DESCRIBE_TAG@"
 #define ECAL_DATE "@GIT_REVISION_DATE@"
 #define ECAL_PLATFORMTOOLSET "@eCAL_PLATFORM_TOOLSET@"
+
+#define ECAL_INSTALL_APP_DIR     "@eCAL_install_app_dir@"
+#define ECAL_INSTALL_SAMPLES_DIR "@eCAL_install_samples_dir@"
+#define ECAL_INSTALL_LIB_DIR     "@eCAL_install_lib_dir@"
+#define ECAL_INSTALL_CONFIG_DIR  "@eCAL_install_config_dir@"
+#define ECAL_INSTALL_INCLUDE_DIR "@eCAL_install_include_dir@"
+#define ECAL_INSTALL_PREFIX      "@CMAKE_INSTALL_PREFIX@"
+
 #endif // ecal_defs_h_included


### PR DESCRIPTION
mon plugins, rec addons and ecal.ini are now loaded by using the paths used by CMake. The CPACK_PACKAGING_INSTALL_PREFIX is set to the CMAKE_INSTALL_PREFIX to achieve that.

Fixes #129