### PR TITLE
Qt is now auto-detected on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
+      with:
+        version: '5.15.2'
+        target: 'desktop'
+        arch: 'win64_msvc2015_64'
 
     - name: Install Dependencies
       run: choco install doxygen.install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,35 +310,9 @@ endif()
 # --------------------------------------------------------
 # detect qt library
 # --------------------------------------------------------
-if(WIN32 AND HAS_QT5)
-  if (NOT DEFINED ENV{QT5_ROOT_DIRECTORY} AND NOT DEFINED ENV{QT5_ROOT})
-    # If the QT5_ROOT_DIRECTORY Variable is not set, there is still a chance that
-    # the user set the CMAKE_PREFIX_PATH himself. Thus we try to find
-    # Qt5 Core just to see if that works. If we can find Qt, we assume
-    # that the user knows what he is doing.
-    find_package(Qt5 COMPONENTS Core)
-    if(NOT Qt5_FOUND)
-      message(FATAL_ERROR "QT5_ROOT_DIRECTORY is not defined. Please create an \
-        environment variable QT5_ROOT_DIRECTORY pointing to your QT5 installation \
-        (the directory that contains the msvc201x or msvc201x_64 \
-        directory) or disable compilation of Qt5 projects by setting \
-        HAS_QT5 to OFF.")
-    endif()
-  else()
-    if (DEFINED ENV{QT5_ROOT})
-      set(qt_directory $ENV{QT5_ROOT})
-      message(WARNING "Please unset the QT5_ROOT environment variable and use \
-        QT5_ROOT_DIRECTORY instead. Using QT5_ROOT will trigger multiple CMake warnings \
-        in newer CMake versions.")
-    endif ()
-    if (DEFINED ENV{QT5_ROOT_DIRECTORY})
-      set(qt_directory $ENV{QT5_ROOT_DIRECTORY})
-    endif ()
-
-    qt_msvc_path(qt_subfolder)
-    list(APPEND CMAKE_PREFIX_PATH ${qt_directory}/${qt_subfolder}/)
-    message(STATUS "Searching for QT in ${qt_directory}/${qt_subfolder}/")
-  endif()
+find_package(Qt5 QUIET)
+if (NOT Qt5_FOUND)
+	autodetect_qt5_msvc_dir()
 endif()
 
 # --------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,9 +310,9 @@ endif()
 # --------------------------------------------------------
 # detect qt library
 # --------------------------------------------------------
-find_package(Qt5 QUIET)
-if (NOT Qt5_FOUND)
-	autodetect_qt5_msvc_dir()
+find_package(Qt5 COMPONENTS Core QUIET)
+if (NOT "${Qt5_FOUND}")
+    autodetect_qt5_msvc_dir()
 endif()
 
 # --------------------------------------------------------

--- a/doc/rst/development/building_ecal_from_source.rst
+++ b/doc/rst/development/building_ecal_from_source.rst
@@ -39,22 +39,14 @@ First check out the eCAL repository and all of the submodules:
 #. Download and install the build-dependencies
 
    * CMake (https://cmake.org)
-   * Qt5 (>= 5.5) (https://www.qt.io/download)
+   * Qt5 (>= 5.5 / 64-bit) (https://www.qt.io/download)
 
-#. Install Qt5 by starting the installer and selecting `msvc2015 32-bit` or `msvc2015 64-bit` (VS2015) or `msvc2017 32-bit` and `msvc2017 64-bit` (VS2017) from the latest Qt5 version.
-   Create an environment variable ``QT5_ROOT_DIRECTORY`` that points to the directory containing the architecture-specific folders.
-   It should look like this:
+   .. note::
 
-   .. code-block:: batch
+      If you have multiple Versions of Qt installed, eCAL will try to pick the latest match for your Visual Studio Version.
 
-      %QT5_ROOT_DIRECTORY%
-         ├ msvc2015
-         ├ msvc2015_64
-         ├ msvc2017
-         └ msvc2017_64
-
-   e.g.: ``QT5_ROOT_DIRECTORY = C:\Qt\5.11.1``
-
+      If this fails (e.g. as you have copied the qt directory without properly installing it) or if you want to use a specific Qt5 Version, you may have to manually set the ``CMAKE_PREFIX_PATH``.
+      
 #. Optional: Install additional dependendencies
 
    * `Python for Windows <https://www.python.org/downloads/>`_ (64 Bit, Version 3.x): To build the python extensions and the documentation

--- a/doc/rst/development/building_ecal_from_source.rst
+++ b/doc/rst/development/building_ecal_from_source.rst
@@ -56,7 +56,7 @@ First check out the eCAL repository and all of the submodules:
 |fa-windows| Windows build
 --------------------------
 
-* To just compile eCAL:
+* **To just compile eCAL**:
 
   .. code-block:: batch
 
@@ -68,10 +68,17 @@ First check out the eCAL repository and all of the submodules:
 
   This will create a :file:`_build\\complete\\` directory in your eCAL root folder and build eCAL there.
 
-* To build even more:
+* **To build a complete setup**:
 
   #. For creating a setup, you have to also build the documentation and build the debug SDK binaries.
-     Execute the following batch files with the appropriate parameter to create the Visual Studio 2015 (v140) / 2017 (v141) / 2019 (v142) solution and build it:
+     
+     The batch files will compile eCAL with the MSVC 2015 Toolset to provide downwards compatibility.
+     Thus, you will need to install:
+
+     - The MSVC 2015 Toolset (-> v140) for your probably newer Visual Studio
+     - Qt5 as ``msvc2015_64`` (Or manually override it by setting ``Qt5_DIR``)
+
+     Execute the following batch files with the appropriate parameter to create the Visual Studio 2015 (v140) / 2017 (v141) / 2019 (v142) solution and build it.
 
      .. code-block:: batch
 

--- a/doc/rst/development/building_ecal_from_source.rst
+++ b/doc/rst/development/building_ecal_from_source.rst
@@ -45,7 +45,7 @@ First check out the eCAL repository and all of the submodules:
 
       If you have multiple Versions of Qt installed, eCAL will try to pick the latest match for your Visual Studio Version.
 
-      If this fails (e.g. as you have copied the qt directory without properly installing it) or if you want to use a specific Qt5 Version, you may have to manually set the ``CMAKE_PREFIX_PATH``.
+      If this fails (e.g. as you have copied the qt directory without properly installing it) or if you want to use a specific Qt5 Version, you may have to manually set the ``CMAKE_PREFIX_PATH`` or ``Qt5_DIR``.
       
 #. Optional: Install additional dependendencies
 

--- a/thirdparty/cmake_functions/qt/qt_msvc_path.cmake
+++ b/thirdparty/cmake_functions/qt/qt_msvc_path.cmake
@@ -16,32 +16,102 @@
 #
 # ========================= eCAL LICENSE =================================
 
+macro(autodetect_qt5_msvc_dir)
+	SET(QT_MISSING True)
+	# msvc only; mingw will need different logic
+	IF(MSVC)
+		message(STATUS "Trying to auto-detect best Qt5 Version")
+		# look for user-registry pointing to qtcreator
+		GET_FILENAME_COMPONENT(QTCREATOR_BIN [HKEY_CURRENT_USER\\Software\\Classes\\Applications\\QtProject.QtCreator.pro\\shell\\Open\\Command] DIRECTORY)
+		# get root path so we can search for 5.3, 5.4, 5.5, etc
+		STRING(REPLACE "/Tools" ";" QT_BIN "${QTCREATOR_BIN}")
 
-# Macro that determines the subfolder in a Qt installation to append the 
-# CMAKE_PREFIX_PATH variable
-macro(qt_msvc_path out)
-if (MSVC_VERSION GREATER_EQUAL 1930)
-  message(WARNING "unknown MSVC_VERSION")
-elseif (MSVC_VERSION GREATER_EQUAL 1920)
-# current qt version does nor support VS2019
-# so we can use the binary compatible VS2017 version instead
-  #message(WARNING "Visual Studio 2019 detected, using VS2017 qt binaries until Qt supports VS2019")
-  set(${out} "msvc2017" ) 
-elseif (MSVC_VERSION GREATER_EQUAL 1910)
-  set(${out} "msvc2017" ) 
-elseif (MSVC_VERSION EQUAL 1900)
-  set(${out} "msvc2015" )  
-elseif (MSVC_VERSION EQUAL 1800)
-  set(${out} "msvc2013" )
-elseif (MSVC_VERSION EQUAL 1700)
-  set(${out} "msvc2012" )
-elseif (MSVC_VERSION EQUAL 1600)
-  set(${out} "msvc2010" )  
-else ()
-  message(FATAL_ERROR "Older Visual Studio Versions are not supported")
-endif()
+		LIST(GET QT_BIN 0 QT_INSTALL_DIRECTORY)
+				
+		# Collect all Qt5 directories
+		FILE(GLOB QT_VERSION_DIRECTORIES "${QT_INSTALL_DIRECTORY}/5.*")
+		
+		# Compute the MSVC Version as year (e.g. 2015, 2017, 2019...) and aim for upwards compatibility
+		if (MSVC_VERSION LESS 1900)
+			message(FATAL_ERROR "ERROR: MSVC_VERSION  is $MSVC_VERSION, which indicates Visual Studio < 2015. Only Visual Studio 2015 and up are supported.")			
+		endif()
+		
+		if (MSVC_VERSION LESS_EQUAL "1909")
+			set(MSVC_YEAR "2015")
+		elseif (MSVC_VERSION LESS_EQUAL "1919")
+			set(MSVC_YEAR "2017")
+		elseif (MSVC_VERSION LESS_EQUAL "1929")
+			set(MSVC_YEAR "2019")
+		else () # Assume each 2 years a new Visual Studio Version with a range of 10 MSVC_VERSIONs
+			MATH(EXPR MSVC_YEAR "2015 + ((${MSVC_VERSION} - 1900) / 10) * 2")
+		endif ()
+		
+		message(STATUS "Detected Visual Studio ${MSVC_YEAR} (from MSVC_VERSION ${MSVC_VERSION})")
+				
+		# Iterate over all Qt Versions and pick the best
+		set(BEST_QT_DIRECTORY "")
+		set(BEST_QT_MSVC_YEAR 0)
+		set(BEST_QT_MAJOR 0)
+		set(BEST_QT_MINOR 0)
+		set(BEST_QT_PATCH 0)
+		
+		foreach (QT_DIRECTORY ${QT_VERSION_DIRECTORIES})
+			# Get last component of path, which is the qt version
+			get_filename_component(QT_VERSION_STRING "${QT_DIRECTORY}" NAME)
+			
+			# Split the string, to get the major, minor and patch
+			STRING(REPLACE "." ";" QT_VERSION_COMPONENT_LIST "${QT_VERSION_STRING}")
 
-if (CMAKE_CL_64)
-  set(${out} "${${out}}_64")
-endif ()
+			LIST(GET QT_VERSION_COMPONENT_LIST 0 QT_MAJOR)
+			LIST(GET QT_VERSION_COMPONENT_LIST 1 QT_MINOR)
+			LIST(GET QT_VERSION_COMPONENT_LIST 2 QT_PATCH)
+
+			# Check if there is an installation we can use
+			if (CMAKE_CL_64)
+				FILE(GLOB QT_MSVC_DIRECTORIES "${QT_DIRECTORY}/msvc20[0-9][0-9]_64")
+			else ()
+				FILE(GLOB QT_MSVC_DIRECTORIES "${QT_DIRECTORY}/msvc20[0-9][0-9]")
+			endif()
+
+			# Iterate over all msvc directories and check for the best matching one
+			foreach (QT_MSVC_DIR ${QT_MSVC_DIRECTORIES})
+				STRING(REPLACE "//" "/"  QT_MSVC_DIR "${QT_MSVC_DIR}")
+				get_filename_component(QT_MSVC_DIR_NAME "${QT_MSVC_DIR}" NAME)
+				
+				STRING(REPLACE "msvc" "" QT_MSVC_YEAR "${QT_MSVC_DIR_NAME}")
+				if (CMAKE_CL_64)
+					STRING(REPLACE "_64" "" QT_MSVC_YEAR "${QT_MSVC_YEAR}")
+				endif()
+				
+				if ("${QT_MSVC_YEAR}" LESS_EQUAL "${MSVC_YEAR}")
+					# At this point we have found a version that should be usable. Let's check if it is better than the last one we found!
+					message(STATUS "Found Qt5 candidate at ${QT_MSVC_DIR}")
+					if ( ("${QT_MAJOR}" GREATER "${BEST_QT_MAJOR}") OR
+						(("${QT_MAJOR}" EQUAL   "${BEST_QT_MAJOR}") AND ("${QT_MINOR}" GREATER "${BEST_QT_MINOR}")) OR
+						(("${QT_MAJOR}" EQUAL   "${BEST_QT_MAJOR}") AND ("${QT_MINOR}" EQUAL   "${BEST_QT_MINOR}") AND ("${QT_PATCH}" GREATER "${BEST_QT_PATCH}")) OR
+						(("${QT_MAJOR}" EQUAL   "${BEST_QT_MAJOR}") AND ("${QT_MINOR}" EQUAL   "${BEST_QT_MINOR}") AND ("${QT_PATCH}" EQUAL   "${BEST_QT_PATCH}") AND ("${QT_MSVC_YEAR}" GREATER "${BEST_QT_MSVC_YEAR}"))
+					   )
+					   
+						set(BEST_QT_DIRECTORY "${QT_MSVC_DIR}")
+						set(BEST_QT_MSVC_YEAR "${QT_MSVC_YEAR}")
+						set(BEST_QT_MAJOR "${QT_MAJOR}")
+						set(BEST_QT_MINOR "${QT_MINOR}")
+						set(BEST_QT_PATCH "${QT_PATCH}")
+					   
+					endif()
+					
+				endif()
+				
+			endforeach()
+		endforeach()
+
+		if ("${BEST_QT_DIRECTORY}" STREQUAL "")
+			message(FATAL_ERROR "ERROR: Unable to find any usable Qt5 installation. Please install Qt5 or manually set the CMAKE_PREFIX_PATH.")
+		endif()
+
+		message(STATUS "Using Qt ${BEST_QT_MAJOR}.${BEST_QT_MINOR}.${BEST_QT_PATCH} MSVC ${BEST_QT_MSVC_YEAR} from ${BEST_QT_DIRECTORY}")
+		SET(Qt5_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt5/")
+		SET(Qt5Test_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt5Test")
+	
+	endif()
 endmacro()


### PR DESCRIPTION
The old QT_ROOT_DIRECTORY is not used anymore. The autodetection aims for upwards-compatibility, which will work as long as Microsoft doesn't change their 2-year-Visual-Studio-schedule and uses 10 MSVC_VERSION numbers per Visual Studio.

Fixes #170 