### PR TITLE
Fixed MSVC and gcc warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if (ECAL_THIRDPARTY_BUILD_SPDLOG)
   
   # Disable warnings for third-party lib
   target_compile_options(spdlog PRIVATE
-    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<CXX_COMPILER_ID:MSVC>:/W0 /wd4996>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
   )
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,16 @@ if (ECAL_THIRDPARTY_BUILD_PROTOBUF)
     set(Protobuf_PROTOC_EXECUTABLE protoc)
   endif()
   set(Protobuf_VERSION 3.11.4)
+  
+  # Disable warnings for third-party lib
+  target_compile_options(protoc PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+  )
+  target_compile_options(libprotobuf PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+  )
 endif()
 
 if (ECAL_THIRDPARTY_BUILD_SPDLOG)
@@ -149,6 +159,12 @@ if (ECAL_THIRDPARTY_BUILD_SPDLOG)
   if (NOT TARGET spdlog::spdlog)
     add_library(spdlog::spdlog ALIAS spdlog)
   endif ()
+  
+  # Disable warnings for third-party lib
+  target_compile_options(spdlog PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+  )
 endif ()
 
 if (ECAL_THIRDPARTY_BUILD_TINYXML2)
@@ -159,6 +175,12 @@ if (ECAL_THIRDPARTY_BUILD_TINYXML2)
   set(BUILD_TESTS OFF CACHE BOOL "My option" FORCE)
   add_subdirectory(thirdparty/tinyxml2 EXCLUDE_FROM_ALL)
   add_library(tinyxml2::tinyxml2 ALIAS tinyxml2)
+  
+  # Disable warnings for third-party lib
+  target_compile_options(tinyxml2 PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+  )
 endif ()
 
 if (ECAL_THIRDPARTY_BUILD_FINEFTP)
@@ -203,7 +225,11 @@ if (ECAL_THIRDPARTY_BUILD_CURL)
   if (NOT TARGET CURL::libcurl)
     add_library(CURL::libcurl ALIAS libcurl)
   endif()
-  
+
+  target_compile_options(libcurl PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+  )
 endif ()
 
 if (ECAL_THIRDPARTY_BUILD_GTEST)
@@ -256,6 +282,10 @@ if (ECAL_THIRDPARTY_BUILD_HDF5)
   endif()
 
   target_include_directories(hdf5-shared INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/thirdparty/hdf5>")
+  target_compile_options(hdf5-shared PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-w>
+)
 endif()
 
 if (ECAL_THIRDPARTY_BUILD_PROTOBUF OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,7 +525,7 @@ if(BUILD_APPS)
   add_subdirectory(app/sys/sys_client_cli)
   add_subdirectory(app/sys/sys_client_core)
   if(NOT APPLE)
-    add_subdirectory(contrib/mma/src)
+    add_subdirectory(contrib/mma)
   endif()
 endif()
 

--- a/app/mon/mon_gui/src/ecalmon.cpp
+++ b/app/mon/mon_gui/src/ecalmon.cpp
@@ -38,7 +38,18 @@
 #include <QDateTime>
 #include <QScreen>
 
-#include <QDebug>
+#ifndef NDEBUG
+  #ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251 4800) // disable QDebug Warnings
+  #endif // _MSC_VER
+
+  #include <QDebug>
+
+  #ifdef _MSC_VER
+    #pragma warning(pop)
+  #endif // _MSC_VER
+#endif // NDEBUG
 
 #include <iomanip>
 #include <string>

--- a/app/mon/mon_gui/src/widgets/log_widget/log_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/log_widget/log_widget.cpp
@@ -23,9 +23,16 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QMenu>
-#include <QDebug>
 #include <QClipboard>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4251) // disable QTextStream warnings
+#endif
 #include <QTextStream>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <ecal/ecal.h>
 

--- a/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
@@ -23,6 +23,11 @@
 
 #include <QDebug>
 
+#ifdef _MSC_VER
+// Disable Qt 5.15 Deprecation Warning about QVariant::operator<(), which is udsed by QMap
+#pragma warning (disable : 4996)
+#endif // _MSC_VER
+
 GroupTreeModel::GroupTreeModel(const QVector<int>& group_by_columns, QObject *parent)
   : QAbstractTreeModel(parent)
   , group_column_header_("Group")

--- a/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
@@ -17,17 +17,31 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#ifdef _MSC_VER
+// Disable Qt 5.15 Deprecation Warning about QVariant::operator<(), which is udsed by QMap
+#pragma warning(push)
+#pragma warning (disable : 4996)
+#endif // _MSC_VER
 #include "group_tree_model.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include "tree_item_type.h"
 #include "item_data_roles.h"
 
-#include <QDebug>
+#ifndef NDEBUG
+  #ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251 4800) // disable QDebug Warnings
+  #endif // _MSC_VER
 
-#ifdef _MSC_VER
-// Disable Qt 5.15 Deprecation Warning about QVariant::operator<(), which is udsed by QMap
-#pragma warning (disable : 4996)
-#endif // _MSC_VER
+  #include <QDebug>
 
+  #ifdef _MSC_VER
+    #pragma warning(pop)
+  #endif // _MSC_VER
+#endif // NDEBUG
 GroupTreeModel::GroupTreeModel(const QVector<int>& group_by_columns, QObject *parent)
   : QAbstractTreeModel(parent)
   , group_column_header_("Group")

--- a/app/mon/mon_gui/src/widgets/models/plugin_table_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/plugin_table_model.cpp
@@ -20,7 +20,6 @@
 #include "plugin_table_model.h"
 
 #include <QMessageBox>
-#include <QDebug>
 
 PluginTableModel::PluginTableModel(QObject *parent) :
   QAbstractItemModel(parent)

--- a/app/mon/mon_gui/src/widgets/visualisation_widget/visualisation_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/visualisation_widget/visualisation_widget.cpp
@@ -26,7 +26,19 @@
 #include <QDateTime>
 #include <QFileDialog>
 #include <QTimer>
-#include <QDebug>
+
+#ifndef NDEBUG
+  #ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4251 4800) // disable QDebug Warnings
+  #endif // _MSC_VER
+
+  #include <QDebug>
+
+  #ifdef _MSC_VER
+    #pragma warning(pop)
+  #endif // _MSC_VER
+#endif // NDEBUG
 
 #include <QLibrary>
 #include <QPluginLoader>

--- a/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
+++ b/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
@@ -50,4 +50,8 @@ if(MSVC)
   )
 endif()
 
+if(MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4127 /wd4714")
+endif()
+
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER app/mon/plugins)

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -83,7 +83,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
         std::transform(file_extension.begin(), file_extension.end(), file_extension.begin(),
                         [](char c) -> char
                         {
-                          return std::tolower(static_cast<int>(c));
+                          return static_cast<char>(std::tolower(static_cast<int>(c)));
                         });
         if (file_extension == ".hdf5")
         {

--- a/app/sys/sys_cli/src/command_executor.h
+++ b/app/sys/sys_cli/src/command_executor.h
@@ -28,10 +28,9 @@
 
 #include <commands/command.h>
 
-#include <ecal/ecal_client.h>
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100 4505 4800)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
 #endif
 #include <ecal/msg/protobuf/client.h>
 #include <ecal/pb/sys/service.pb.h>

--- a/app/sys/sys_cli/src/commands/command.h
+++ b/app/sys/sys_cli/src/commands/command.h
@@ -27,9 +27,10 @@
 #include <ecalsys/ecal_sys.h>
 
 #include <ecal/ecal_client.h>
+
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100 4505 4800)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
 #endif
 #include <ecal/msg/protobuf/client.h>
 #include <ecal/pb/sys/service.pb.h>

--- a/app/sys/sys_cli/src/commands/helpers.h
+++ b/app/sys/sys_cli/src/commands/helpers.h
@@ -27,9 +27,10 @@
 #include <ecalsys/ecal_sys.h>
 
 #include <ecal/ecal_client.h>
+
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100 4505 4800)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
 #endif
 #include <ecal/pb/sys/service.pb.h>
 #ifdef _MSC_VER

--- a/app/sys/sys_cli/src/commands/list.cpp
+++ b/app/sys/sys_cli/src/commands/list.cpp
@@ -28,7 +28,14 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #endif // _WIN32
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4800) // disable termcolor warnings
+#endif
 #include <termcolor/termcolor.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <ecal_utils/string.h>
 

--- a/app/sys/sys_cli/src/ecalsys_cli.cpp
+++ b/app/sys/sys_cli/src/ecalsys_cli.cpp
@@ -45,7 +45,15 @@
 
 #include "ecalsys_service.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4505) // disable tclap warning (unreferenced local function has been removed)
+#endif
 #include "tclap/CmdLine.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include <custom_tclap/advanced_tclap_output.h>
 #include <custom_tclap/fuzzy_value_switch_arg.h>
 

--- a/app/sys/sys_cli/src/ecalsys_cli.cpp
+++ b/app/sys/sys_cli/src/ecalsys_cli.cpp
@@ -36,7 +36,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4100 4505 4800)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
 #endif
 #include <ecal/pb/sys/service.pb.h>
 #ifdef _MSC_VER

--- a/app/sys/sys_cli/src/ecalsys_service.h
+++ b/app/sys/sys_cli/src/ecalsys_service.h
@@ -24,8 +24,15 @@
 #pragma once
 
 // protobuf remote control
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
+#endif
 #include "ecal/pb/sys/service.pb.h"
 #include "ecal/pb/sys/state.pb.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 class eCALSysServiceImpl : public eCAL::pb::sys::Service
 {

--- a/app/sys/sys_client_cli/src/ecal_sys_client_cli.cpp
+++ b/app/sys/sys_client_cli/src/ecal_sys_client_cli.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
     std::string user_input;
     std::getline (std::cin, user_input);
 
-    std::transform(user_input.begin(), user_input.end(), user_input.begin(), [](unsigned char c){ return std::tolower(c); });
+    std::transform(user_input.begin(), user_input.end(), user_input.begin(), [](unsigned char c) -> char { return static_cast<char>(std::tolower(static_cast<int>(c))); });
     if (user_input == std::string("i accept"))
     {
       logger->warn("");

--- a/app/sys/sys_gui/src/widgets/treemodels/group_tree_item.cpp
+++ b/app/sys/sys_gui/src/widgets/treemodels/group_tree_item.cpp
@@ -76,7 +76,7 @@ QVariant GroupTreeItem::data(Columns column, Qt::ItemDataRole role) const
     }
   }
 
-  else if (role == Qt::ItemDataRole::BackgroundColorRole)
+  else if (role == Qt::ItemDataRole::BackgroundRole)
   {
     if (column == Columns::STATE)
     {

--- a/app/util/launcher/src/main_window.cpp
+++ b/app/util/launcher/src/main_window.cpp
@@ -79,22 +79,22 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 
 void MainWindow::on_pushButton_monitor_clicked()
 {
-  QProcess::startDetached(QString(eCAL::Apps::MON_GUI));
+  QProcess::startDetached(QString(eCAL::Apps::MON_GUI), QStringList());
 }
 
 void MainWindow::on_pushButton_sys_clicked()
 {
-  QProcess::startDetached(QString(eCAL::Apps::SYS_GUI));
+  QProcess::startDetached(QString(eCAL::Apps::SYS_GUI), QStringList());
 }
 
 void MainWindow::on_pushButton_play_clicked()
 {
-  QProcess::startDetached(QString(eCAL::Apps::PLAY_GUI));
+  QProcess::startDetached(QString(eCAL::Apps::PLAY_GUI), QStringList());
 }
 
 void MainWindow::on_pushButton_rec_clicked()
 {
-  QProcess::startDetached(QString(eCAL::Apps::REC_GUI));
+  QProcess::startDetached(QString(eCAL::Apps::REC_GUI), QStringList());
 }
 
 void MainWindow::on_pushButton_info_clicked()

--- a/app/util/launcher/src/main_window.cpp
+++ b/app/util/launcher/src/main_window.cpp
@@ -79,22 +79,22 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 
 void MainWindow::on_pushButton_monitor_clicked()
 {
-  QProcess::startDetached(eCAL::Apps::MON_GUI);
+  QProcess::startDetached(QString(eCAL::Apps::MON_GUI));
 }
 
 void MainWindow::on_pushButton_sys_clicked()
 {
-  QProcess::startDetached(eCAL::Apps::SYS_GUI);
+  QProcess::startDetached(QString(eCAL::Apps::SYS_GUI));
 }
 
 void MainWindow::on_pushButton_play_clicked()
 {
-  QProcess::startDetached(eCAL::Apps::PLAY_GUI);
+  QProcess::startDetached(QString(eCAL::Apps::PLAY_GUI));
 }
 
 void MainWindow::on_pushButton_rec_clicked()
 {
-  QProcess::startDetached(eCAL::Apps::REC_GUI);
+  QProcess::startDetached(QString(eCAL::Apps::REC_GUI));
 }
 
 void MainWindow::on_pushButton_info_clicked()

--- a/app/util/launcher/src/main_window.cpp
+++ b/app/util/launcher/src/main_window.cpp
@@ -23,7 +23,7 @@
 
 #include "main_window.h"
 #include "ui_main_window.h"
-#include "qpushbutton.h"
+#include <QPushButton>
 
 #include <ecal/ecal_apps.h>
 

--- a/app/util/launcher/src/main_window.h
+++ b/app/util/launcher/src/main_window.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <QWidget>
-#include <QtGui>
 #include <QMainWindow>
 #include <QMouseEvent>
 
@@ -44,10 +43,10 @@ public:
   explicit MainWindow(QWidget *parent = 0);
   ~MainWindow();
   bool eventFilter(QObject * watched, QEvent * event);
-  public slots:
+public slots:
   void mousePressEvent(QMouseEvent * event);
 
-  private slots:
+private slots:
   void on_pushButton_monitor_clicked();
   void on_pushButton_sys_clicked();
   void on_pushButton_play_clicked();

--- a/contrib/mma/CMakeLists.txt
+++ b/contrib/mma/CMakeLists.txt
@@ -21,43 +21,62 @@ project(mma)
 find_package(Threads REQUIRED)
 find_package(Protobuf REQUIRED)
 
+set(mma_src
+  include/interruptable_timer.h
+  include/logger.h
+  include/mma.h
+  include/mma_defs.h
+  include/mma_impl.h
+  include/query_manager.h
+  include/zombie_instance_killer.h
+
+  src/logger.cpp
+  src/mma.cpp
+  src/mma_application.cpp
+  src/query_manager.cpp
+  src/zombie_instance_killer.cpp
+)
 if(WIN32)
-  set(mma_src
-    mma_application.cpp
-    mma.cpp
-    logger.cpp
-    zombie_instance_killer.cpp
-    query_manager.cpp
-    windows/disk.cpp
-    windows/memory.cpp
-    windows/mma_windows.cpp
-    windows/network.cpp
-    windows/processes.cpp
-    windows/processor.cpp
-    windows/ressource.cpp
+  list(APPEND mma_src
+    include/windows/disk.h
+    include/windows/memory.h
+    include/windows/mma_windows.h
+    include/windows/network.h
+    include/windows/process.h
+    include/windows/processes.h
+    include/windows/processor.h
+    include/windows/ressource.h
+    
+    src/windows/disk.cpp
+    src/windows/memory.cpp
+    src/windows/mma_windows.cpp
+    src/windows/network.cpp
+    src/windows/process.cpp
+    src/windows/processes.cpp
+    src/windows/processor.cpp
+    src/windows/ressource.cpp
   )
 else()
-  set(mma_src
-    mma_application.cpp
-    mma.cpp
-    logger.cpp
-    zombie_instance_killer.cpp
-    query_manager.cpp
-    linux/mma_linux.cpp
-    linux/pipe_refresher.cpp
+  list(APPEND mma_src
+    include/linux/mma_linux.h
+    include/linux/pipe_refresher.h
+    include/linux/ressource.h
+    
+    src/linux/mma_linux.cpp
+    src/linux/pipe_refresher.cpp
   )
 endif()
 
 if(WIN32)
   set(mma_win_src
-      mma.rc
+      src/mma.rc
   )
 endif()
 
 ecal_add_app_console(${PROJECT_NAME} ${mma_src} ${mma_win_src})
 
 target_include_directories(${PROJECT_NAME}
-  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
+  PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 create_targets_protobuf()
 
@@ -69,5 +88,12 @@ target_link_libraries(${PROJECT_NAME}
   $<$<BOOL:${WIN32}>:wbemuuid.lib>)
 
 ecal_install_app(${PROJECT_NAME})
+
+if(MSVC)
+  msvc_source_tree(
+    ${mma_src}
+    ${mma_win_src}
+  )
+endif()
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER contrib)

--- a/contrib/mma/include/mma.h
+++ b/contrib/mma/include/mma.h
@@ -19,7 +19,14 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
+#endif
 #include "ecal/pb/mma/mma.pb.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 class MMAImpl;
 

--- a/contrib/mma/include/mma_impl.h
+++ b/contrib/mma/include/mma_impl.h
@@ -19,7 +19,14 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
+#endif
 #include "ecal/pb/mma/mma.pb.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 class MMAImpl
 {

--- a/contrib/mma/include/windows/mma_windows.h
+++ b/contrib/mma/include/windows/mma_windows.h
@@ -40,7 +40,14 @@
 #include "../mma_impl.h"
 #include "../query_manager.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
+#endif
 #include "ecal/pb/mma/mma.pb.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 class MMAWindows : public MMAImpl
 {

--- a/contrib/mma/src/mma_application.cpp
+++ b/contrib/mma/src/mma_application.cpp
@@ -34,7 +34,14 @@
 #include "../include/zombie_instance_killer.h"
 #include "../include/interruptable_timer.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800) // disable proto warnings
+#endif
 #include "ecal/pb/mma/mma.pb.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #ifdef ECAL_OS_WINDOWS
 #include <windows.h>

--- a/ecal/core/src/service/ecal_tcpclient.cpp
+++ b/ecal/core/src/service/ecal_tcpclient.cpp
@@ -184,7 +184,7 @@ namespace eCAL
       if (bytes_transferred == sizeof(tcp_header))
       {
         const auto resp_size = static_cast<size_t>(ntohl(tcp_header->psize_n));
-        ReceiveResponseData(resp_size, callback_);
+        this->ReceiveResponseData(resp_size, callback_);
       }
       else
       {

--- a/ecal/pb/CMakeLists.txt
+++ b/ecal/pb/CMakeLists.txt
@@ -47,7 +47,7 @@ protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLD
 
 target_compile_options(${PROJECT_NAME}
   PRIVATE
-    #$<$<CXX_COMPILER_ID:MSVC>:/W0>
+    $<$<CXX_COMPILER_ID:MSVC>:/wd4505>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-unused-parameter>)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/lib/CustomQt/include/CustomQt/QSizeHintFrame.h
+++ b/lib/CustomQt/include/CustomQt/QSizeHintFrame.h
@@ -30,7 +30,7 @@ class QSizeHintFrame : public QFrame
   Q_OBJECT
 
 public:
-  QSizeHintFrame(QWidget* parent = nullptr, Qt::WindowFlags flags = 0);
+  QSizeHintFrame(QWidget* parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
   ~QSizeHintFrame();
 
   QSize sizeHint() const;

--- a/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
@@ -76,6 +76,10 @@ if(WIN32)
 endif()
 
 if(MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4127 /wd4714")
+endif()
+
+if(MSVC)
     # Create a source tree that mirrors the filesystem
     msvc_source_tree(
         ${source_files}

--- a/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
+++ b/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
@@ -159,10 +159,18 @@ void EcalplayGuiClient::commandRequest()
   {
     auto channel_map = command_request.mutable_channel_mapping();
     
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QStringList lines = ui_.command_request_channel_mapping_textedit->toPlainText().split("\n", Qt::SplitBehaviorFlags::SkipEmptyParts);
+#else // QT_VERSION
+    QStringList lines = ui_.command_request_channel_mapping_textedit->toPlainText().split("\n", QString::SplitBehavior::SkipEmptyParts);
+#endif // QT_VERSION
     for (auto& line : lines)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       QStringList mapping_list = line.split("=", Qt::SplitBehaviorFlags::SkipEmptyParts);
+#else // QT_VERSION
+      QStringList mapping_list = line.split("=", QString::SplitBehavior::SkipEmptyParts);
+#endif // QT_VERSION
       if (mapping_list.size() == 2)
       {
         (*channel_map)[mapping_list.at(0).trimmed().toStdString()] = mapping_list.at(1).trimmed().toStdString();

--- a/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
+++ b/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
@@ -159,10 +159,10 @@ void EcalplayGuiClient::commandRequest()
   {
     auto channel_map = command_request.mutable_channel_mapping();
     
-    QStringList lines = ui_.command_request_channel_mapping_textedit->toPlainText().split("\n", QString::SkipEmptyParts);
+    QStringList lines = ui_.command_request_channel_mapping_textedit->toPlainText().split("\n", Qt::SplitBehaviorFlags::SkipEmptyParts);
     for (auto& line : lines)
     {
-      QStringList mapping_list = line.split("=", QString::SkipEmptyParts);
+      QStringList mapping_list = line.split("=", Qt::SplitBehaviorFlags::SkipEmptyParts);
       if (mapping_list.size() == 2)
       {
         (*channel_map)[mapping_list.at(0).trimmed().toStdString()] = mapping_list.at(1).trimmed().toStdString();

--- a/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
@@ -75,6 +75,10 @@ if(WIN32)
 endif(WIN32)
 
 if(MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4127 /wd4714")
+endif()
+
+if(MSVC)
     # Create a source tree that mirrors the filesystem
     msvc_source_tree(
         ${source_files}

--- a/thirdparty/cmake_functions/protoc_functions/protoc_generate_cpp.cmake
+++ b/thirdparty/cmake_functions/protoc_functions/protoc_generate_cpp.cmake
@@ -86,7 +86,7 @@ cmake_parse_arguments(INPUT ""
   endif(MSVC)
 
   if(UNIX)
-    set_source_files_properties(${INPUT_CPP_FILES} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+    set_source_files_properties(${INPUT_CPP_FILES} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
   endif(UNIX)
 
   # This adds the pb.h and pb.cc files to the project


### PR DESCRIPTION
eCAL is now compile-warning-free up to gcc 10.2 / MSVC 2019 / Qt 5.15.
Also fixed a compile issue on Ubuntu 16.04 (gcc 5).