### PR TITLE
Removed samples and test-builds for macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,7 +15,7 @@ jobs:
       uses: jurplel/install-qt-action@v2
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf@3.6 hdf5
+      run: brew install ninja doxygen graphviz protobuf hdf5
 
     - name: Install Cap’n Proto
       run: |
@@ -49,11 +49,11 @@ jobs:
         -DHAS_CAPNPROTO=ON \
         -DBUILD_DOCS=ON \
         -DBUILD_APPS=ON \
-        -DBUILD_SAMPLES=ON \
+        -DBUILD_SAMPLES=OFF \
         -DBUILD_TIME=ON \
         -DBUILD_PY_BINDING=ON \
         -DBUILD_CSHARP_BINDING=OFF \
-        -DBUILD_ECAL_TESTS=ON \
+        -DBUILD_ECAL_TESTS=OFF \
         -DECAL_LAYER_ICEORYX=OFF \
         -DECAL_INCLUDE_PY_SAMPLES=OFF \
         -DECAL_INSTALL_SAMPLE_SOURCES=ON \

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,7 +15,7 @@ jobs:
       uses: jurplel/install-qt-action@v2
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5
+      run: brew install ninja doxygen graphviz protobuf@3.6 hdf5
 
     - name: Install Cap’n Proto
       run: |


### PR DESCRIPTION
The new Protobuf Version (3.15.4) prevents compiling of samples. See #199 