### PR TITLE
Feature/libatomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,17 @@ if(UNIX)
   message(STATUS "GCC detected - Adding flags")
   set(CMAKE_CXX_STANDARD 14)
   add_definitions(-Wall -Wextra -std=c++14)
+
+  set(ATOMIC_TEST_CODE "
+      #include <atomic>
+      int main() { std::atomic<int64_t> i(0); i++; return 0; }
+  ")
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("${ATOMIC_TEST_CODE}" ATOMIC_IS_BUILTIN)
+  if (NOT ATOMIC_IS_BUILTIN)
+      message(STATUS "Adding -latomic flag, as this plattform does not support 64bit atomic operations out of the box.")
+      add_definitions(-latomic)
+  endif ()
 endif()
 
 # --------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if(UNIX)
   check_cxx_source_compiles("${ATOMIC_TEST_CODE}" ATOMIC_IS_BUILTIN)
   if (NOT ATOMIC_IS_BUILTIN)
       message(STATUS "Adding -latomic flag, as this plattform does not support 64bit atomic operations out of the box.")
-      add_definitions(-latomic)
+      set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
   endif ()
 endif()
 


### PR DESCRIPTION
Added code that checks whether libatomic is needed and adds it to the global CMAKE_CXX_LINK_FLAGS if required.

libatomic is needed by certain 32bit plattforms, e.g. armhf Raspbian on a Raspberry Pi 3
Fixes #207 