### PR TITLE
added cmake minumim required version and protobuf static lib link (#201)

### DIFF
--- a/samples/c/minimal/minimal_rec/CMakeLists.txt
+++ b/samples/c/minimal/minimal_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(minimal_rec_c)
 
 find_package(eCAL REQUIRED)

--- a/samples/c/minimal/minimal_rec_cb/CMakeLists.txt
+++ b/samples/c/minimal/minimal_rec_cb/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(minimal_rec_cb_c)
 
 find_package(eCAL REQUIRED)

--- a/samples/c/minimal/minimal_snd/CMakeLists.txt
+++ b/samples/c/minimal/minimal_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(minimal_snd_c)
 
 find_package(eCAL REQUIRED)

--- a/samples/c/services/service_client/CMakeLists.txt
+++ b/samples/c/services/service_client/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(service_client_c)
 
 find_package(eCAL REQUIRED)

--- a/samples/c/services/service_server/CMakeLists.txt
+++ b/samples/c/services/service_server/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(service_server_c)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/capnp/addressbook_rec/CMakeLists.txt
+++ b/samples/cpp/capnp/addressbook_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(addressbook_rec)
 
 find_package(CapnProto REQUIRED)

--- a/samples/cpp/capnp/addressbook_rec_cb/CMakeLists.txt
+++ b/samples/cpp/capnp/addressbook_rec_cb/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(addressbook_rec_cb)
 
 find_package(CapnProto REQUIRED)

--- a/samples/cpp/capnp/addressbook_rec_dynamic/CMakeLists.txt
+++ b/samples/cpp/capnp/addressbook_rec_dynamic/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(addressbook_rec_dynamic)
 
 find_package(CapnProto REQUIRED)

--- a/samples/cpp/capnp/addressbook_snd/CMakeLists.txt
+++ b/samples/cpp/capnp/addressbook_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(addressbook_snd)
 
 find_package(CapnProto REQUIRED)

--- a/samples/cpp/counter/counter_rec_cb/CMakeLists.txt
+++ b/samples/cpp/counter/counter_rec_cb/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(counter_rec_cb)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/counter/counter_snd/CMakeLists.txt
+++ b/samples/cpp/counter/counter_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(counter_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/event/event_rec/CMakeLists.txt
+++ b/samples/cpp/event/event_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(event_rec)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/event/event_snd/CMakeLists.txt
+++ b/samples/cpp/event/event_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(event_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/latency/latency_rec/CMakeLists.txt
+++ b/samples/cpp/latency/latency_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(latency_rec)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/latency/latency_rec_cb/CMakeLists.txt
+++ b/samples/cpp/latency/latency_rec_cb/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(latency_rec_cb)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/latency/latency_snd/CMakeLists.txt
+++ b/samples/cpp/latency/latency_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(latency_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/measurement/measurement_read/CMakeLists.txt
+++ b/samples/cpp/measurement/measurement_read/CMakeLists.txt
@@ -16,6 +16,15 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
+project(measurement_read)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
+
 find_package(eCAL REQUIRED)
 
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/measurement/measurement_write/CMakeLists.txt
+++ b/samples/cpp/measurement/measurement_write/CMakeLists.txt
@@ -16,6 +16,15 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
+project(measurement_write)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
+
 find_package(eCAL REQUIRED)
 
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/minimal/minimal_rec/CMakeLists.txt
+++ b/samples/cpp/minimal/minimal_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(minimal_rec)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/minimal/minimal_snd/CMakeLists.txt
+++ b/samples/cpp/minimal/minimal_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(minimal_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/misc/process/CMakeLists.txt
+++ b/samples/cpp/misc/process/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(process)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/misc/proto_dyn/CMakeLists.txt
+++ b/samples/cpp/misc/proto_dyn/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(proto_dyn)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/misc/proto_dyn_json/CMakeLists.txt
+++ b/samples/cpp/misc/proto_dyn_json/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(proto_dyn_json)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 

--- a/samples/cpp/misc/time/CMakeLists.txt
+++ b/samples/cpp/misc/time/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(time)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/misc/timer/CMakeLists.txt
+++ b/samples/cpp/misc/timer/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(timer)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
+++ b/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(monitoring_rec)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/monitoring/monitoring_reg/CMakeLists.txt
+++ b/samples/cpp/monitoring/monitoring_reg/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(monitoring_reg)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/multiple/multiple_rec_cb/CMakeLists.txt
+++ b/samples/cpp/multiple/multiple_rec_cb/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(multiple_rec_cb)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/multiple/multiple_snd/CMakeLists.txt
+++ b/samples/cpp/multiple/multiple_snd/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(multiple_snd)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/performance/dynsize_snd/CMakeLists.txt
+++ b/samples/cpp/performance/dynsize_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(dynsize_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/performance/performance_rec/CMakeLists.txt
+++ b/samples/cpp/performance/performance_rec/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(performance_rec)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/performance/performance_rec_cb/CMakeLists.txt
+++ b/samples/cpp/performance/performance_rec_cb/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(performance_rec_cb)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/performance/performance_snd/CMakeLists.txt
+++ b/samples/cpp/performance/performance_snd/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(performance_snd)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/performance/pubsub_throughput/CMakeLists.txt
+++ b/samples/cpp/performance/pubsub_throughput/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(pubsub_throughput)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/person/person_rec/CMakeLists.txt
+++ b/samples/cpp/person/person_rec/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_rec)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_rec_events/CMakeLists.txt
+++ b/samples/cpp/person/person_rec_events/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_rec_events)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_rec_lambda_in_class/CMakeLists.txt
+++ b/samples/cpp/person/person_rec_lambda_in_class/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_rec_lambda_in_class)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_snd/CMakeLists.txt
+++ b/samples/cpp/person/person_snd/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_snd)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_snd_events/CMakeLists.txt
+++ b/samples/cpp/person/person_snd_events/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_snd_events)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_snd_inproc/CMakeLists.txt
+++ b/samples/cpp/person/person_snd_inproc/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_snd_inproc)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/person/person_snd_multicast/CMakeLists.txt
+++ b/samples/cpp/person/person_snd_multicast/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(person_snd_multicast)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/pingpong/ping/CMakeLists.txt
+++ b/samples/cpp/pingpong/ping/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ping)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/pingpong/pong/CMakeLists.txt
+++ b/samples/cpp/pingpong/pong/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(pong)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/ecalplayer_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_client/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ecalplayer_client)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ecalplayer_gui_client)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/ecalrpcservice_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalrpcservice_client/CMakeLists.txt
@@ -16,12 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ecalrpcservice_client)
 
 find_package(eCAL REQUIRED)
 
 set(ecalrpcservice_client_src
-  ecalrpcservice_client.cpp
+  src/ecalrpcservice_client.cpp
 )
 
 ecal_add_sample(${PROJECT_NAME} ${ecalrpcservice_client_src})

--- a/samples/cpp/services/ecalsys_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalsys_client/CMakeLists.txt
@@ -16,12 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ecalsys_client)
 
 find_package(eCAL REQUIRED)
 
 set(ecalsys_client_src
-  ecalsys_client.cpp
+  src/ecalsys_client.cpp
 )
 
 ecal_add_sample(${PROJECT_NAME} ${ecalsys_client_src})

--- a/samples/cpp/services/math_client/CMakeLists.txt
+++ b/samples/cpp/services/math_client/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(math_client)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/services/math_server/CMakeLists.txt
+++ b/samples/cpp/services/math_server/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(math_server)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/services/ping_client/CMakeLists.txt
+++ b/samples/cpp/services/ping_client/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ping_client)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/services/ping_server/CMakeLists.txt
+++ b/samples/cpp/services/ping_server/CMakeLists.txt
@@ -16,7 +16,14 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(ping_server)
+
+if(MSVC)
+  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
+  set (Protobuf_USE_STATIC_LIBS TRUE) 
+endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/samples/cpp/services/rec_client_service_cli/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_cli/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 project(rec_client_service_cli)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 set(PROJECT_NAME rec_client_service_gui)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
@@ -16,6 +16,8 @@
 #
 # ========================= eCAL LICENSE =================================
 
+cmake_minimum_required(VERSION 3.0)
+
 set(PROJECT_NAME rec_server_service_gui)
 
 find_package(eCAL REQUIRED)


### PR DESCRIPTION
cmake_minimum_required(VERSION 3.0)

if(MSVC)
  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
  set (Protobuf_USE_STATIC_LIBS TRUE)
endif()