### PR TITLE
Update requirements.txt (bump jinja2 to 2.11.3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ docutils==0.16
 exhale==0.2.3
 idna==2.10
 imagesize==1.2.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 lxml
 MarkupSafe==1.1.1
 packaging==20.4


### PR DESCRIPTION
jinja2 vulnerability found in requirements.txt 8 hours ago

Vulnerable versions: < 2.11.3
Patched version: 2.11.3
This affects the package jinja2 from 0.0.0 and before 2.11.3. The ReDOS vulnerability of the regex is mainly due to the sub-pattern [a-zA-Z0-9.-]+.[a-zA-Z0-9.-]+ This issue can be mitigated by Markdown to format user content instead of the urlize filter, or by implementing request timeouts and limiting process memory.