### PR TITLE
Cross-compilation (arm64) example and build fixture, some CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,20 @@ if (ECAL_THIRDPARTY_BUILD_PROTOBUF)
     )
   endif()
 
-  if (NOT TARGET protobuf::protoc)
+  if (NOT TARGET protoc_imported AND CMAKE_CROSSCOMPILING)
+    # In cross compile scenario, we don't build protoc, so we need
+    # to find and import it so downstream usage will use the host compiler.
+
+    # find_program will search the host paths if CMAKE_FIND_ROOT_PATH_MODE_PROGRAM 
+    # is configured correctly (see toolchain file)
+    find_program(protoc_path NAMES protoc REQUIRED)
+    add_executable(protoc_imported IMPORTED)
+    set_target_properties(protoc_imported PROPERTIES IMPORTED_LOCATION ${protoc_path})
+    set_target_properties(protoc_imported PROPERTIES IMPORTED_GLOBAL TRUE)
+    
+    add_executable(protobuf::protoc ALIAS protoc_imported)
+    set(Protobuf_PROTOC_EXECUTABLE protoc_imported)
+  elseif(NOT TARGET protobuf::protoc)
     add_executable(protobuf::protoc ALIAS protoc)
     set(Protobuf_PROTOC_EXECUTABLE protoc)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 project(eCAL)
+set(ECAL_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}")
 
 # --------------------------------------------------------
 # command line build options

--- a/cmake/Modules/Findasio.cmake
+++ b/cmake/Modules/Findasio.cmake
@@ -1,10 +1,11 @@
 find_path(Asio_INCLUDE_DIR
   NAMES asio.hpp
   HINTS
-    include ${CONAN_ASIO_ROOT}/include
-    ${CMAKE_SOURCE_DIR}/thirdparty/asio/asio/include
-    include
-  )
+    "${CONAN_ASIO_ROOT}/include"
+    "${ECAL_PROJECT_ROOT}/thirdparty/asio/asio/include"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
 
 if(Asio_INCLUDE_DIR-NOTFOUND)
   message(FATAL_ERROR "Could not find Asio library")

--- a/cmake/Modules/Findsimpleini.cmake
+++ b/cmake/Modules/Findsimpleini.cmake
@@ -1,10 +1,11 @@
 find_path(simpleini_INCLUDE_DIR
   NAMES SimpleIni.h
   HINTS
-    include
-    ${CONAN_SIMPLEINI_ROOT}/include
-    ${CMAKE_SOURCE_DIR}/thirdparty/simpleini
-  )
+    "${CONAN_SIMPLEINI_ROOT}/include"
+    "${ECAL_PROJECT_ROOT}/thirdparty/simpleini"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
 
 if(simpleini_INCLUDE_DIR-NOTFOUND)
   message(FATAL_ERROR "Could not find simpleini library")

--- a/cmake/Modules/Findtclap.cmake
+++ b/cmake/Modules/Findtclap.cmake
@@ -1,10 +1,11 @@
 find_path(tclap_INCLUDE_DIR
   NAMES tclap/Arg.h
-  HINTS
-    include
-    ${CONAN_TCLAP_ROOT}/include
-    ${CMAKE_SOURCE_DIR}/thirdparty/tclap/include
-  )
+  HINTS    
+    "${CONAN_TCLAP_ROOT}/include"
+    "${ECAL_PROJECT_ROOT}/thirdparty/tclap/include"
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
 
 if(tclap_INCLUDE_DIR-NOTFOUND)
   message(FATAL_ERROR "Could not find tclap library")

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -18,7 +18,14 @@
 
 project(hdf5)
 
-find_package(HDF5 COMPONENTS C REQUIRED)
+if(NOT CMAKE_CROSSCOMPILING)
+  find_package(HDF5 COMPONENTS C REQUIRED)
+else()
+  find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)
+  find_path(hdf5_include NAMES hdf5.h PATH_SUFFIXES hdf5/serial REQUIRED)  
+  set(HDF5_LIBRARIES "${hdf5_path};m;dl;z;sz;pthread")
+  set(HDF5_INCLUDE_DIRS "${hdf5_include}")
+endif()
 
 set(ecalhdf5_src
     src/eh5_meas.cpp

--- a/testing/contrib/cross/.dockerignore
+++ b/testing/contrib/cross/.dockerignore
@@ -1,0 +1,1 @@
+artifacts

--- a/testing/contrib/cross/.gitignore
+++ b/testing/contrib/cross/.gitignore
@@ -1,0 +1,2 @@
+artifacts
+build

--- a/testing/contrib/cross/Makefile
+++ b/testing/contrib/cross/Makefile
@@ -20,9 +20,16 @@ run-host: build-host
 		ecal-crossbuild-host \
 		/bin/bash
 
-ecal:
+clean-target:
+	rm -rf artifacts
+
+clean:
 	rm -rf build
-	mkdir build
+
+prebuild:
+	mkdir -p build
+
+ecal: prebuild
 	cmake -Bbuild -H../../../ \
 		-DCMAKE_TOOLCHAIN_FILE=$(PWD)/toolchain-arm64.cmake \
 		-DCMAKE_BUILD_TYPE=Release \

--- a/testing/contrib/cross/Makefile
+++ b/testing/contrib/cross/Makefile
@@ -1,0 +1,35 @@
+setup_qemu:
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+build-target-sysroot: setup_qemu
+	docker build -t sysroot-example:ubuntu18 -f ./target/ubuntu18.Dockerfile --build-arg BASEIMAGE=arm64v8/ubuntu:18.04 .
+	docker run --rm -d --entrypoint /bin/bash --name sysroot-example sysroot-example:ubuntu18 -c 'while sleep 3600; do :; done'
+	mkdir -p ./artifacts/sysroot
+	docker export sysroot-example > ./artifacts/sysroot.tar
+	docker stop sysroot-example
+	tar xf ./artifacts/sysroot.tar -C ./artifacts/sysroot/
+
+build-host:
+	docker build -f ./host/Dockerfile -t ecal-crossbuild-host:latest .
+
+run-host: build-host
+	docker run --rm -it \
+		-u $(shell id -u):$(shell id -u) \
+		-v $(PWD)/../../..:/workspaces/ecal \
+		-w /workspaces/ecal/testing/contrib/cross \
+		ecal-crossbuild-host \
+		/bin/bash
+
+ecal:
+	rm -rf build
+	mkdir build
+	cmake -Bbuild -H../../../ \
+		-DCMAKE_TOOLCHAIN_FILE=$(PWD)/toolchain-arm64.cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DECAL_THIRDPARTY_BUILD_PROTOBUF=ON \
+		-DECAL_THIRDPARTY_BUILD_CURL=OFF \
+		-DECAL_THIRDPARTY_BUILD_HDF5=OFF \
+		-DECAL_THIRDPARTY_BUILD_CURL=ON \
+		-DHAS_QT5=OFF
+	
+	cmake --build build -j $(shell nproc)

--- a/testing/contrib/cross/README.md
+++ b/testing/contrib/cross/README.md
@@ -1,0 +1,18 @@
+# Cross-compilation testing suite
+
+## Quickstart
+
+```
+# Build an example arm64 Ubuntu sysroot containing some 
+# pre-built dependencies replicating potential user situation.
+make build-target-sysroot
+
+# Create a generic C++ debian build container
+make build-host
+
+# Go into container with shell
+make run-host
+
+# Cross-compile eCAL.
+make ecal
+```

--- a/testing/contrib/cross/host/Dockerfile
+++ b/testing/contrib/cross/host/Dockerfile
@@ -1,7 +1,15 @@
+# This base "host" image is a simple Debian-based C++ dev container provided
+# as part of the MS VSCode remote dev container project.
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.159.0/containers/cpp/.devcontainer/base.Dockerfile
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends crossbuild-essential-arm64 protobuf-compiler
+    && apt-get -y install --no-install-recommends crossbuild-essential-arm64
+
+# Install the exact protobuf compiler version on the host as the libprotoc we build for target.
+RUN git clone https://github.com/protocolbuffers/protobuf.git && \
+    cd protobuf && git checkout v3.11.4 && mkdir build && \
+    cmake -Bbuild -Hcmake -Dprotobuf_BUILD_TESTS=off && \
+    cmake --build build -j 8 --target install

--- a/testing/contrib/cross/host/Dockerfile
+++ b/testing/contrib/cross/host/Dockerfile
@@ -1,0 +1,7 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.159.0/containers/cpp/.devcontainer/base.Dockerfile
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends crossbuild-essential-arm64 protobuf-compiler

--- a/testing/contrib/cross/target/ubuntu18.Dockerfile
+++ b/testing/contrib/cross/target/ubuntu18.Dockerfile
@@ -1,0 +1,15 @@
+ARG BASEIMAGE=ubuntu/bionic
+FROM ${BASEIMAGE}
+
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+
+# This replicates having a sysroot available with installed/prebuilt dependencies
+# listed below. This may come from user's build system or provided by third party prior to reaching this point.
+# Different configurations can be tested by changing this dependency list.
+# Here we have protobuf, hdf5, and libssl (but not curl)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libhdf5-dev \
+    libssl-dev \
+    zlib1g-dev

--- a/testing/contrib/cross/target/ubuntu18.Dockerfile
+++ b/testing/contrib/cross/target/ubuntu18.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=ubuntu/bionic
+ARG BASEIMAGE=arm64v8/ubuntu:18.04
 FROM ${BASEIMAGE}
 
 ENV LC_ALL C.UTF-8
@@ -8,8 +8,13 @@ ENV DEBIAN_FRONTEND noninteractive
 # This replicates having a sysroot available with installed/prebuilt dependencies
 # listed below. This may come from user's build system or provided by third party prior to reaching this point.
 # Different configurations can be tested by changing this dependency list.
-# Here we have protobuf, hdf5, and libssl (but not curl)
+# Here we have hdf5, and libssl (but not curl or protobuf)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libhdf5-dev \
     libssl-dev \
     zlib1g-dev
+
+# Utility converts symlinks to relative since we will export this filesystem.
+RUN apt-get install -y symlinks
+RUN symlinks -cr /usr/lib/aarch64-linux-gnu
+RUN symlinks -cr /lib/aarch64-linux-gnu

--- a/testing/contrib/cross/toolchain-arm64.cmake
+++ b/testing/contrib/cross/toolchain-arm64.cmake
@@ -1,0 +1,18 @@
+set(WORKSPACE_ROOT "/workspaces/ecal")
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(cross_triple "aarch64-linux-gnu")
+set(cross_root /usr/bin/${cross_triple})
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+set(CMAKE_SYSROOT "${WORKSPACE_ROOT}/testing/contrib/cross/artifacts/sysroot")
+
+set(CMAKE_FIND_ROOT_PATH ${cross_root} ${CMAKE_SYSROOT})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Adds a set of files under `testing/contrib/cross` which allows one to quickly setup a cross-compilation environment example and test the building of eCAL using this environment. 

There are two Docker containers constructed: "target" and "host"

The "target" is a simple arm64 container (built using QEMU) used to emulate having an ARM64 system root with some pre-built binaries, for example libssl and hdf5. The exact libraries present can be changed in order to test different build scenarios/flags. 

The "host" is a basic C++ Debian environment with GCC8 aarch64 compiler and an updated Protobuf compiler installed.

The build script provided in the README executes a sequence of steps:

1. dump the "target" container's filesystem so it can be referenced by the cross toolchain
2. spin up the "host" and use the example CMake toolchain and the system root to perform the cross-compilation. 

This setup allows you to emulate the most straightforward cross compilation scenario.

Using this, I found a few items in the CMake lists which needed to change. 
1. find_path for internal dependencies - these changes should be compatible with native builds since you only want to search your source tree (from what I understand).
2. For handling hdf5, this is an existing issue with CMake's FindHDF5 script ,see also CMake gitlab [issue](https://gitlab.kitware.com/cmake/cmake/-/issues/20819) , FindHDF5.cmake will report host libraries when you want target libraries. In this case, I handle finding the library and header paths directly, but obviously there may be other types of HDF5 installs? Probably this should get factored out into a Module similar to the other modules present under `./cmake/`

Building HDF5 from source in cross-compile scenario is a little more complicated, you have to supply data type sizes, etc in the toolchain, and I didn't really try to explore that. A quick google search makes me think cross building HDF5 is probably a nightmare, so I'm not going to touch that.

3. For handling protobuf, there was an issue [earlier](https://github.com/continental/ecal/issues/187) for someone saying they did `add_executable` to import `protoc` in their `toolchain.cmake`, but that didn't work for me and seems unorthodox. It seems more canonical to handle overriding protoc in the main CMakelists.