### PR TITLE
Add some explicit includes to support building with GCC 11

### DIFF
--- a/app/rec/rec_addon_core/src/time_limited_queue.h
+++ b/app/rec/rec_addon_core/src/time_limited_queue.h
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <thread>
 #include <functional>
+#include <condition_variable>
 
 template <class T>
 class TimeLimtedQueue : public std::enable_shared_from_this<TimeLimtedQueue<T>>

--- a/samples/cpp/multiple/multiple_snd/src/multiple_snd.cpp
+++ b/samples/cpp/multiple/multiple_snd/src/multiple_snd.cpp
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <memory>
 
 #define PAYLOAD_SIZE      1024
 #define PRINT_LOG            0


### PR DESCRIPTION
As discussed in #285, here's the pull request.

It only adds two explicit includes that are no longer implicitly available with GCC 11.