### PR TITLE
Fixed RelWithDebInfo and MinSizeRel mode for QT

### DIFF
--- a/cmake/eCALConfig.cmake.in
+++ b/cmake/eCALConfig.cmake.in
@@ -27,8 +27,8 @@ set(eCAL_VERSION_PATCH  @eCAL_VERSION_PATCH@)
 set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
 
 # eCAL is provided only with Release and Debug Version, thus map the other configs to Release build.
-set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release)
-set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)
+set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release "")
+set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release "")
 
 find_package(Protobuf REQUIRED)
 


### PR DESCRIPTION
CMake currently does not resolve the path to QT's RCC compiler properly in RelWithDebInfo and in MinSizeRel mode.
In these cases currently it tries to search the compiler with a suffix "Release" however this compiler is not specific to the Build_Type.
In the issue mentioned below it is requested that the compiler should fall back to no suffix in this case.
However as cmake does not support this fallback, they proposed a workaround to provide an empty string.
This works quite fine on my side. However I currently have to manually override this file every time I am updating the conan dependencies