### PR TITLE
Downgraded Sphinx again

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -169,7 +169,7 @@ language = None
 exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'none'
+pygments_style = 'native'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ wheel
 PyGithub
 empy
 semantic-version 
-sphinx-tabs==3.1.0
+sphinx-tabs==2.1.0
 alabaster
 Babel
 beautifulsoup4
@@ -26,7 +26,7 @@ requests
 six
 snowballstemmer
 soupsieve
-Sphinx==4.0.2
+Sphinx==3.5.4
 sphinx-typo3-theme==4.5.2
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp


### PR DESCRIPTION
Sphinx 4 seems to have severe issues rendering code-blocks nicely. This kinda disqualifies it unfortunately. So let's try this again with Sphinx 3.5.4 and hope everything just looks as it used to look.

The issues with Sphinx 4 are:
- The API becomes unreadable, Sphinx chooses a light color scheme on a light background
- The default color scheme for code blocks is a dark scheme on dark background. This can be changes though, via pygments_style.
- The Line numbers in code-blocks get selected too, when selecting the text with the mouse. So copy and paste has the line-numbers at the beginning of each line. Everybody hates that.