### PR TITLE
Enable ASAN compiler options with ECAL tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ endif()
 if(UNIX)
   message(STATUS "GCC detected - Adding flags")
   set(CMAKE_CXX_STANDARD 14)
-  add_definitions(-Wall -Wextra -std=c++14)
+  add_definitions(-Wall -Wextra)
 
   set(ATOMIC_TEST_CODE "
       #include <atomic>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,8 +423,9 @@ if(UNIX)
       set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
   endif ()
   if(BUILD_ECAL_TESTS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -g")
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsanitize=address")
+    add_compile_options(
+    "$<$<CONFIG:ASAN>:-fsanitize=address;-fno-omit-frame-pointer;-g>")
+    add_link_options("$<$<CONFIG:ASAN>:-fsanitize=address>")
   endif(BUILD_ECAL_TESTS)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,10 @@ if(UNIX)
       message(STATUS "Adding -latomic flag, as this plattform does not support 64bit atomic operations out of the box.")
       set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
   endif ()
+  if(BUILD_ECAL_TESTS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -g")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -fsanitize=address")
+  endif(BUILD_ECAL_TESTS)
 endif()
 
 # --------------------------------------------------------

--- a/ecal/core/src/ecal_thread.cpp
+++ b/ecal/core/src/ecal_thread.cpp
@@ -68,6 +68,9 @@ namespace eCAL
 
       // ok the thread is stopped
       m_tdata.is_started = false;
+
+      gCloseEvent(m_tdata.event);
+
     }
 
     return(1);

--- a/testing/ecal/event_test/src/event_test.cpp
+++ b/testing/ecal/event_test/src/event_test.cpp
@@ -38,4 +38,7 @@ TEST(Event, EventSetGet)
 
   // get set event
   EXPECT_EQ(true, gWaitForEvent(event_handle, 100));
+
+  // close the event
+  EXPECT_EQ(true, eCAL::gCloseEvent(event_handle));
 }


### PR DESCRIPTION
This is the first step for enable AddressSanitizer for checking memory issue [1] .Please give feedback.

After applying, detected some mem leak  in the ecore_test some memleak issues still in investigation.

[1] https://github.com/google/sanitizers/wiki/AddressSanitizer
