### PR TITLE
Core/Udpcap: Fixed IP reassembly

### DIFF
--- a/lib/Udpcap/CMakeLists.txt
+++ b/lib/Udpcap/CMakeLists.txt
@@ -28,6 +28,8 @@ set (source_files
     include/udpcap/udpcap_socket.h
     
     src/host_address.cpp
+    src/ip_reassembly.cpp
+    src/ip_reassembly.h
     src/log_debug.h
     src/npcap_helpers.cpp
     src/udpcap_socket.cpp

--- a/lib/Udpcap/src/ip_reassembly.cpp
+++ b/lib/Udpcap/src/ip_reassembly.cpp
@@ -1,0 +1,170 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+ */
+
+#include "ip_reassembly.h"
+
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable: 4100 4200)
+#endif // _MSC_VER
+#include <IPv4Layer.h>
+#include <IPv6Layer.h>
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif // _MSC_VER
+
+#include <iostream>
+
+namespace Udpcap
+{
+  /////////////////////////////////////////
+  /// Constructor & Destructor
+  /////////////////////////////////////////
+  
+  IpReassembly::IpReassembly(std::chrono::nanoseconds max_package_age, size_t max_packets_to_store)
+    : max_package_age_(max_package_age)
+    , ip_reassembly_(&IpReassembly::onFragmentsCleanCallback, static_cast<void*>(this), max_packets_to_store)
+  {}
+
+  /////////////////////////////////////////
+  /// API borrowed from pcpp::IPReassembly
+  /////////////////////////////////////////
+  
+  pcpp::Packet* IpReassembly::processPacket(pcpp::Packet* fragment, pcpp::IPReassembly::ReassemblyStatus& status, pcpp::ProtocolType parse_until, pcpp::OsiModelLayer parse_until_layer)
+  {
+    removeOldPackages();
+
+    pcpp::Packet* packet = ip_reassembly_.processPacket(fragment, status, parse_until, parse_until_layer);
+
+    if ((status & pcpp::IPReassembly::REASSEMBLED) != 0)
+    {
+      // We have reassembled an entire packet.
+      auto packet_key = getPacketKey(fragment);
+      removePackageFromTimestampMap(std::move(packet_key));
+    }
+    else if ((status & (pcpp::IPReassembly::FIRST_FRAGMENT | pcpp::IPReassembly::FRAGMENT | pcpp::IPReassembly::OUT_OF_ORDER_FRAGMENT)) != 0)
+    {
+      // The input was a fragment an will be kept in the buffer
+      auto packet_key = getPacketKey(fragment);
+      updatePackageInTimestampMap(std::move(packet_key));
+    }
+
+    return packet;
+  }
+
+  pcpp::Packet* IpReassembly::processPacket(pcpp::RawPacket* fragment, pcpp::IPReassembly::ReassemblyStatus& status, pcpp::ProtocolType parse_until, pcpp::OsiModelLayer parse_until_layer)
+  {
+    pcpp::Packet* parsedFragment = new pcpp::Packet(fragment, false, parse_until, parse_until_layer);
+    pcpp::Packet* result         = this->processPacket(parsedFragment, status, parse_until, parse_until_layer);
+
+    if (result != parsedFragment)
+      delete parsedFragment;
+
+    return result;
+  }
+
+  /////////////////////////////////////////
+  /// Helper functions
+  /////////////////////////////////////////
+
+  std::unique_ptr<pcpp::IPReassembly::PacketKey> IpReassembly::getPacketKey(pcpp::Packet* packet)
+  {
+    {
+      pcpp::IPv4Layer* ipv4_layer  = packet->getLayerOfType<pcpp::IPv4Layer>();
+      if (ipv4_layer)
+      {
+        return std::make_unique<pcpp::IPReassembly::IPv4PacketKey>(_byteswap_ushort(ipv4_layer->getIPv4Header()->ipId), ipv4_layer->getSrcIPv4Address(), ipv4_layer->getDstIPv4Address());
+      }
+    }
+    
+    {
+      pcpp::IPv6Layer* ipv6_layer  = packet->getLayerOfType<pcpp::IPv6Layer>();
+      if (ipv6_layer)
+      {
+        auto frag_header = ipv6_layer->getExtensionOfType<pcpp::IPv6FragmentationHeader>();
+        if (frag_header)
+          return std::make_unique<pcpp::IPReassembly::IPv6PacketKey>(ntohl(frag_header->getFragHeader()->id), ipv6_layer->getSrcIPv6Address(), ipv6_layer->getDstIPv6Address());
+        else
+          return nullptr;
+      }
+    }
+
+    return nullptr;
+  }
+
+  void IpReassembly::removeOldPackages()
+  {
+    auto now = std::chrono::steady_clock::now();
+
+    for (auto package_timestamp_it = timestamp_map_.begin()
+      ; package_timestamp_it != timestamp_map_.end()
+      ; package_timestamp_it++)
+    {
+      if (package_timestamp_it->second.second < (now - max_package_age_))
+      {
+        ip_reassembly_.removePacket(*package_timestamp_it->second.first);
+        package_timestamp_it = timestamp_map_.erase(package_timestamp_it);
+      }
+    }
+
+    if (timestamp_map_.size() != ip_reassembly_.getCurrentCapacity())
+    {
+      std::cerr << "Udpcap: Pcap++ IpReassembly and custom IP Reassembly are outof sync! Pcap++ reassembly capacity: " << ip_reassembly_.getCurrentCapacity() << ", timestamp_map size: " << timestamp_map_.size() << std::endl;
+    }
+  }
+
+  void IpReassembly::removePackageFromTimestampMap(std::unique_ptr<pcpp::IPReassembly::PacketKey> packet_key)
+  {
+    auto package_it = timestamp_map_.find(packet_key->getHashValue());
+    if (package_it != timestamp_map_.end())
+    {
+      timestamp_map_.erase(package_it);
+    }
+  }
+
+  void IpReassembly::updatePackageInTimestampMap(std::unique_ptr<pcpp::IPReassembly::PacketKey> packet_key)
+  {
+    auto now = std::chrono::steady_clock::now();
+
+    auto package_it = timestamp_map_.find(packet_key->getHashValue());
+    if (package_it != timestamp_map_.end())
+    {
+      package_it->second.second = now;
+    }
+    else
+    {
+      timestamp_map_.emplace(packet_key->getHashValue(), std::make_pair(std::move(packet_key), now));
+    }
+  }
+
+  void IpReassembly::onFragmentsCleanCallback(const pcpp::IPReassembly::PacketKey* packt_key, void* this_ptr)
+  {
+    IpReassembly* this_ = static_cast<IpReassembly*>(this_ptr);
+    auto it_to_erase = this_->timestamp_map_.find(packt_key->getHashValue());
+
+    if(it_to_erase != this_->timestamp_map_.end())
+    {
+      this_->timestamp_map_.erase(it_to_erase);
+    }
+    else
+    {
+      std::cerr << "Udpcap: Pcap++ deleted an IP Fragment that we did not know anything about!" << std::endl;
+    }
+  }
+}

--- a/lib/Udpcap/src/ip_reassembly.h
+++ b/lib/Udpcap/src/ip_reassembly.h
@@ -1,0 +1,157 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+ */
+
+#pragma once
+
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable: 4800 4200 4100)
+#endif // _MSC_VER
+#include <IPReassembly.h>   // Pcap++ de-fragmentation of IP packets
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif // _MSC_VER
+
+#include <chrono>
+#include <unordered_map>
+#include <memory>
+
+namespace Udpcap
+{
+  class IpReassembly
+  {
+
+  /////////////////////////////////////////
+  /// Constructor & Destructor
+  /////////////////////////////////////////
+  public: // TODO: Document
+	/**
+	  * A c'tor for this class.
+	  * 
+	  * @param[in] max_package_age The maximum age that a packet may have for being used for reassembly.
+	  * @param[in] max_packets_to_store Set the capacity limit of the IP reassembly mechanism. Default capacity is #PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE
+	  */
+	IpReassembly(std::chrono::nanoseconds max_package_age, size_t max_packets_to_store = PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE);
+
+	~IpReassembly() = default;
+
+	// Disable copy and move construction, as we need the this pointer as callback cookie. So this must never change.
+	IpReassembly ( const IpReassembly & ) = delete;
+	void operator=( const IpReassembly & ) = delete;
+	IpReassembly ( IpReassembly && ) = delete;
+	void operator=( const IpReassembly && ) = delete;
+
+
+  /////////////////////////////////////////
+  /// API borrowed from pcpp::IPReassembly
+  /////////////////////////////////////////
+  
+  public:
+	/**
+	  * The main API that drives IPReassembly. This method should be called whenever a fragment arrives. This method finds the relevant
+	  * packet this fragment belongs to and runs the IP reassembly logic that is described in IPReassembly.h.
+	  * @param[in] fragment The fragment to process (IPv4 or IPv6). Please notice that the reassembly logic doesn't change or manipulate
+	  * this object in any way. All of its data is copied to internal structures and manipulated there
+	  * @param[out] status An indication of the packet reassembly status following the processing of this fragment. Possible values are:
+	  * - The input fragment is not a IPv4 or IPv6 packet
+	  * - The input fragment is not a IPv4 or IPv6 fragment packet
+	  * - The input fragment is the first fragment of the packet
+	  * - The input fragment is not the first or last fragment
+	  * - The input fragment came out-of-order, meaning that wasn't the fragment that was currently expected (it's data is copied to
+	  *   the out-of-order fragment list)
+	  * - The input fragment is malformed and will be ignored
+	  * - The input fragment is the last one and the packet is now fully reassembled. In this case the return value will contain
+	  *   a pointer to the reassebmled packet
+	  * @param[in] parse_until Optional parameter. Parse the reassembled packet until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
+	  * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means don't take this
+	  * parameter into account
+	  * @param[in] parse_until_layer Optional parameter. Parse the reassembled packet until you reach a certain layer in the OSI model (inclusive). Can be useful for cases when you need to
+	  * parse only up to a certain OSI layer (for example transport layer) and want to avoid the performance impact and memory consumption of parsing the whole packet.
+	  * Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
+	  * @return
+	  * - If the input fragment isn't an IPv4/IPv6 packet or if it isn't an IPv4/IPv6 fragment, the return value is a pointer to the input fragment
+	  * - If the input fragment is the last one and the reassembled packet is ready - a pointer to the reassembled packet is
+	  *   returned. Notice it's the user's responsibility to free this pointer when done using it
+	  * - If the reassembled packet isn't ready then NULL is returned
+	  */
+	pcpp::Packet* processPacket(pcpp::Packet* fragment, pcpp::IPReassembly::ReassemblyStatus& status, pcpp::ProtocolType parse_until = pcpp::UnknownProtocol, pcpp::OsiModelLayer parse_until_layer = pcpp::OsiModelLayerUnknown);
+
+	/**
+	  * The main API that drives IPReassembly. This method should be called whenever a fragment arrives. This method finds the relevant
+	  * packet this fragment belongs to and runs the IPv4 reassembly logic that is described in IPReassembly.h.
+	  * @param[in] fragment The fragment to process (IPv4 or IPv6). Please notice that the reassembly logic doesn't change or manipulate
+	  * this object in any way. All of its data is copied to internal structures and manipulated there
+	  * @param[out] status An indication of the packet reassembly status following the processing of this fragment. Possible values are:
+	  * - The input fragment is not a IPv4 or IPv6 packet
+	  * - The input fragment is not a IPv4 or IPv6 fragment packet
+	  * - The input fragment is the first fragment of the packet
+	  * - The input fragment is not the first or last fragment
+	  * - The input fragment came out-of-order, meaning that wasn't the fragment that was currently expected (it's data is copied to
+	  *   the out-of-order fragment list)
+	  * - The input fragment is malformed and will be ignored
+	  * - The input fragment is the last one and the packet is now fully reassembled. In this case the return value will contain
+	  *   a pointer to the reassebmled packet
+	  * @param[in] parse_until Optional parameter. Parse the raw and reassembled packets until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
+	  * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means don't take this
+	  * parameter into account
+	  * @param[in] parse_until_layer Optional parameter. Parse the raw and reassembled packets until you reach a certain layer in the OSI model (inclusive). Can be useful for cases when you need to
+	  * parse only up to a certain OSI layer (for example transport layer) and want to avoid the performance impact and memory consumption of parsing the whole packet.
+	  * Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
+	  * @return
+	  * - If the input fragment isn't an IPv4/IPv6 packet or if it isn't an IPv4/IPv6 fragment, the return value is a pointer to a Packet object
+	  *   wrapping the input fragment RawPacket object. It's the user responsibility to free this instance
+	  * - If the input fragment is the last one and the reassembled packet is ready - a pointer to the reassembled packet is
+	  *   returned. Notice it's the user's responsibility to free this pointer when done using it
+	  * - If the reassembled packet isn't ready then NULL is returned
+	  */
+	pcpp::Packet* processPacket(pcpp::RawPacket* fragment, pcpp::IPReassembly::ReassemblyStatus& status, pcpp::ProtocolType parse_until = pcpp::UnknownProtocol, pcpp::OsiModelLayer parse_until_layer = pcpp::OsiModelLayerUnknown);
+	// TODO: Implement rawPacket function
+
+	/**
+	  * Get the maximum capacity as determined in the c'tor
+	  */
+	size_t getMaxCapacity() const { return ip_reassembly_.getMaxCapacity(); }
+
+	/**
+	  * Get the current number of packets being processed
+	  */
+	size_t getCurrentCapacity() const { return ip_reassembly_.getCurrentCapacity(); }
+
+  /////////////////////////////////////////
+  /// Helper functions
+  /////////////////////////////////////////
+  private:
+
+	std::unique_ptr<pcpp::IPReassembly::PacketKey> getPacketKey(pcpp::Packet* packet);
+
+	void removeOldPackages();
+	void removePackageFromTimestampMap(std::unique_ptr<pcpp::IPReassembly::PacketKey> packet_key);
+	void updatePackageInTimestampMap  (std::unique_ptr<pcpp::IPReassembly::PacketKey> packet_key);
+
+	static void onFragmentsCleanCallback(const pcpp::IPReassembly::PacketKey* packt_key, void* this_ptr);
+
+  /////////////////////////////////////////
+  /// Member variables
+  /////////////////////////////////////////
+  private:
+    const std::chrono::nanoseconds                            max_package_age_;
+    pcpp::IPReassembly                                        ip_reassembly_;
+    std::unordered_map<int32_t, std::pair<std::unique_ptr<pcpp::IPReassembly::PacketKey>, std::chrono::steady_clock::time_point>> timestamp_map_;
+  };
+}

--- a/lib/Udpcap/src/udpcap_socket_private.cpp
+++ b/lib/Udpcap/src/udpcap_socket_private.cpp
@@ -44,14 +44,14 @@ namespace Udpcap
     , bound_state_(false)
     , bound_port_(0)
     , multicast_loopback_enabled_(true)
-    , receive_buffer_(-1)
+    , receive_buffer_size_(-1)
   {
     is_valid_ = Udpcap::Initialize();
   }
 
   UdpcapSocketPrivate::~UdpcapSocketPrivate()
   {
-    // @todo: reinvestigate why it crashes on close.
+    // @todo: reinvestigate why it crashes on close. (Maybe check if i have implemented copy / move constructors properly)
     //close();
   }
 
@@ -203,7 +203,7 @@ namespace Udpcap
       return false;
     }
 
-    receive_buffer_ = buffer_size;
+    receive_buffer_size_ = buffer_size;
 
     return true;
   }
@@ -285,7 +285,7 @@ namespace Udpcap
     auto wait_until = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
 
     std::vector<char> datagram;
-    CallbackArgsVector callback_args(&datagram, source_address, source_port, bound_port_, pcpp::LinkLayerType::LINKTYPE_NULL, &ip_reassembly_);
+    CallbackArgsVector callback_args(&datagram, source_address, source_port, bound_port_, pcpp::LinkLayerType::LINKTYPE_NULL);
 
     do
     {
@@ -309,7 +309,8 @@ namespace Udpcap
       {
         int dev_index = (wait_result - WAIT_OBJECT_0);
         
-        callback_args.link_type_ = static_cast<pcpp::LinkLayerType>(pcap_datalink(pcap_devices_[dev_index].pcap_handle_));
+        callback_args.link_type_     = static_cast<pcpp::LinkLayerType>(pcap_datalink(pcap_devices_[dev_index].pcap_handle_));
+        callback_args.ip_reassembly_ = ip_reassembly_[dev_index].get();
 
         pcap_dispatch(pcap_devices_[dev_index].pcap_handle_, 1, UdpcapSocketPrivate::PacketHandlerVector, reinterpret_cast<u_char*>(&callback_args));
 
@@ -374,7 +375,7 @@ namespace Udpcap
     bool wait_forever = (timeout_ms == INFINITE);
     auto wait_until = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
 
-    CallbackArgsRawPtr callback_args(data, max_len, source_address, source_port, bound_port_, pcpp::LinkLayerType::LINKTYPE_NULL, &ip_reassembly_);
+    CallbackArgsRawPtr callback_args(data, max_len, source_address, source_port, bound_port_, pcpp::LinkLayerType::LINKTYPE_NULL);
 
     do
     {
@@ -398,7 +399,8 @@ namespace Udpcap
       {
         int dev_index = (wait_result - WAIT_OBJECT_0);
 
-        callback_args.link_type_ = static_cast<pcpp::LinkLayerType>(pcap_datalink(pcap_devices_[dev_index].pcap_handle_));
+        callback_args.link_type_     = static_cast<pcpp::LinkLayerType>(pcap_datalink(pcap_devices_[dev_index].pcap_handle_));
+        callback_args.ip_reassembly_ = ip_reassembly_[dev_index].get();
 
         pcap_dispatch(pcap_devices_[dev_index].pcap_handle_, 1, UdpcapSocketPrivate::PacketHandlerRawPtr, reinterpret_cast<u_char*>(&callback_args));
 
@@ -536,8 +538,9 @@ namespace Udpcap
       LOG_DEBUG(std::string("Closing ") + pcap_dev.device_name_);
       pcap_close(pcap_dev.pcap_handle_);
     }
-    pcap_devices_.clear();
+    pcap_devices_      .clear();
     pcap_win32_handles_.clear();
+    ip_reassembly_     .clear();
 
     bound_state_ = false;
     bound_port_ = 0;
@@ -661,9 +664,9 @@ namespace Udpcap
     pcap_set_promisc(pcap_handle, 1 /*true*/); // We only want Packets destined for this adapter. We are not interested in others.
     pcap_set_immediate_mode(pcap_handle, 1 /*true*/);
 
-    if (receive_buffer_ > 0)
+    if (receive_buffer_size_ > 0)
     {
-      pcap_set_buffer_size(pcap_handle, receive_buffer_);
+      pcap_set_buffer_size(pcap_handle, receive_buffer_size_);
     }
 
     int errorcode = pcap_activate(pcap_handle);
@@ -703,8 +706,9 @@ namespace Udpcap
 
     PcapDev pcap_dev(pcap_handle, IsLoopbackDevice(device_name), device_name);
    
-    pcap_devices_.push_back(pcap_dev);
+    pcap_devices_      .push_back(pcap_dev);
     pcap_win32_handles_.push_back(pcap_getevent(pcap_handle));
+    ip_reassembly_     .emplace_back(std::make_unique<Udpcap::IpReassembly>(std::chrono::seconds(5)));
 
     return true;
   }
@@ -858,7 +862,7 @@ namespace Udpcap
         // Handle fragmented IP traffic
         pcpp::IPReassembly::ReassemblyStatus status;
 
-        // Try to reasseble packet
+        // Try to reassemble packet
         pcpp::Packet* reassembled_packet = callback_args->ip_reassembly_->processPacket(&rawPacket, status);
 
         // If we are done reassembling the packet, we return it to the user
@@ -890,7 +894,7 @@ namespace Udpcap
     if (dst_port == callback_args->bound_port_)
     {
       if (callback_args->source_address_)
-        *callback_args->source_address_ = HostAddress(ip_layer->getSrcIpAddress().toInt());
+        *callback_args->source_address_ = HostAddress(ip_layer->getSrcIPv4Address().toInt());
 
       if (callback_args->source_port_)
         *callback_args->source_port_ = ntohs(udp_layer->getUdpHeader()->portSrc);
@@ -951,7 +955,7 @@ namespace Udpcap
     if (dst_port == callback_args->bound_port_)
     {
       if (callback_args->source_address_)
-        *callback_args->source_address_ = HostAddress(ip_layer->getSrcIpAddress().toInt());
+        *callback_args->source_address_ = HostAddress(ip_layer->getSrcIPv4Address().toInt());
 
       if (callback_args->source_port_)
         *callback_args->source_port_ = ntohs(udp_layer->getUdpHeader()->portSrc);


### PR DESCRIPTION
Earlier versions of Udpcap had an issue with IP Reassembly. The issue actually was inside the used Pcap++ library, which would store fragments basically forever. The IPv4 ID however is only a 16 bit value, which overflows quite easily. So once this value overflows, the Pcap++ library will mix up old and new fragments and create faulty IP packets.

The issue was solved by wrapping the Pcap++ IPReassembly class with a custom one. The outer class keeps track of the last-use-timestamp for all packets that haven't been assembled, yet. When a packet is tool old it will be removed from the Pcap++ IPReassembly and not used any more.