### PR TITLE
Add ros2 msg reflection plugin to ecal_mon_gui.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ doc/extensions/_autogen
 .idea
 cmake-build-*
 
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ECAL_PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}")
 # command line build options
 # use it that way cmake .. -DBUILD_APPS=ON -DBUILD_SAMPLES=ON
 # --------------------------------------------------------
+option(HAS_ROS2                                "Platform supports ROS2 library"                                    OFF)
 option(HAS_HDF5                                "Platform supports HDF5 library"                                    ON)
 option(HAS_QT5                                 "Platform supports Qt 5 library"                                    ON)
 option(HAS_CURL                                "Build with CURL (i.e. upload support in the recorder app)"         ON)
@@ -127,7 +128,7 @@ set(possible_subprojects
   CMakeFunctions
 )
 
-# We should rename the option, but don't know how to do in in a 
+# We should rename the option, but don't know how to do in in a
 # backwards compatible way
 set(ECAL_THIRDPARTY_BUILD_CMAKEFUNCTIONS ${ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS})
 

--- a/app/mon/mon_plugins/CMakeLists.txt
+++ b/app/mon/mon_plugins/CMakeLists.txt
@@ -5,9 +5,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,3 +24,6 @@ add_subdirectory(capnproto_reflection)
 endif (HAS_CAPNPROTO)
 add_subdirectory(raw_data_reflection)
 add_subdirectory(string_reflection)
+if(HAS_ROS2)
+add_subdirectory(ros2_reflection)
+endif()

--- a/app/mon/mon_plugins/ros2_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/ros2_reflection/CMakeLists.txt
@@ -1,0 +1,81 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2019 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(mon_plugin_ros2_reflection VERSION 0.1.0)
+
+find_package(Qt5 COMPONENTS
+    Core
+    Widgets
+REQUIRED)
+
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(rosidl_runtime_cpp QUIET)
+find_package(rosidl_generator_cpp QUIET)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC OFF) # Reason for being turned off: AutoUIC will prevent VS from detecting changes in .ui files
+set(CMAKE_AUTORCC OFF) # Reason for being turned off: AutoRCC will create an entirely new project in VS which clutters the solution appearance. Additionally, we cannot assign a source group to the generated .cpp files which will clutter the project.
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(${PROJECT_NAME}_src
+  src/plugin_widget.cpp
+  src/plugin.cpp
+)
+
+set(${PROJECT_NAME}_header
+  src/plugin_widget.h
+  src/plugin.h
+)
+
+set(${PROJECT_NAME}_ui
+  src/plugin_widget.ui
+)
+
+qt5_wrap_ui(autogen_ui ${${PROJECT_NAME}_ui})
+
+ecal_add_mon_plugin(${PROJECT_NAME}
+  SOURCES ${${PROJECT_NAME}_src} ${${PROJECT_NAME}_header} ${${PROJECT_NAME}_ui} ${autogen_ui}
+  METADATA src/metadata.json
+)
+
+create_targets_protobuf()
+target_link_libraries (${PROJECT_NAME} Qt5::Widgets eCAL::core eCAL::mon_plugin_lib)
+
+if(MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4127 /wd4714")
+ENDIF(MSVC)
+
+target_include_directories(${PROJECT_NAME} PRIVATE src)
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
+
+ament_target_dependencies(${PROJECT_NAME}
+    "std_msgs"
+    "rosidl_runtime_cpp"
+    "rosidl_generator_cpp"
+)
+
+ecal_install_mon_plugin(${PROJECT_NAME})
+
+if (TARGET mon)
+add_dependencies(mon ${PROJECT_NAME})
+endif()
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIGURATION>/${ECAL_MON_PLUGIN_DIR}
+  FOLDER app/mon/plugins)

--- a/app/mon/mon_plugins/ros2_reflection/src/metadata.json
+++ b/app/mon/mon_plugins/ros2_reflection/src/metadata.json
@@ -1,0 +1,15 @@
+{
+  "Version": "v0.1.0",
+  "Author": "Zhensheng Li",
+  "Name": "ROS2 Reflection",
+
+  "Priority": 1,
+
+  "SupportedTopics":
+    [
+      {
+      }
+    ],
+
+  "OptionalTopics": []
+}

--- a/app/mon/mon_plugins/ros2_reflection/src/plugin.cpp
+++ b/app/mon/mon_plugins/ros2_reflection/src/plugin.cpp
@@ -1,0 +1,28 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "plugin_widget.h"
+#include "plugin.h"
+
+using namespace eCAL::mon;
+
+PluginWidgetInterface* Plugin::create(const QString& topic_name, const QString& topic_type, QWidget* parent)
+{
+  return new PluginWidget(topic_name, topic_type, parent);
+}

--- a/app/mon/mon_plugins/ros2_reflection/src/plugin.h
+++ b/app/mon/mon_plugins/ros2_reflection/src/plugin.h
@@ -1,0 +1,31 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/mon/plugin.h>
+
+class Plugin : public QObject, public eCAL::mon::PluginInterface
+{
+  Q_OBJECT
+  Q_PLUGIN_METADATA(IID "de.conti.ecal.monitor.plugin.ros2-reflection/v0.1.0" FILE "metadata.json")
+  Q_INTERFACES(eCAL::mon::PluginInterface)
+public:
+  virtual eCAL::mon::PluginWidgetInterface* create(const QString& topic_name, const QString& topic_type, QWidget* parent = Q_NULLPTR);
+};

--- a/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.cpp
@@ -1,0 +1,220 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "plugin_widget.h"
+
+#include <QFrame>
+#include <QLayout>
+#include <QFont>
+
+#include <QDebug>
+
+// msg
+#include "std_msgs/msg/string.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+using rosidl_generator_traits::is_message;
+using rosidl_generator_traits::is_service;
+using rosidl_generator_traits::is_service_request;
+using rosidl_generator_traits::is_service_response;
+using rosidl_generator_traits::to_yaml;
+using rosidl_generator_traits::name;
+
+PluginWidget::PluginWidget(const QString& topic_name, const QString& topic_type, QWidget* parent): QWidget(parent),
+  subscriber_(topic_name.toStdString()),
+  topic_name_(topic_name),
+  topic_type_(topic_type),
+  last_message_publish_timestamp_(eCAL::Time::ecal_clock::time_point(eCAL::Time::ecal_clock::duration(-1))),
+  new_msg_available_(false),
+  received_message_counter_(0)
+{
+  ui_.setupUi(this);
+
+  // Timestamp warning
+  int label_height = ui_.publish_timestamp_warning_label->sizeHint().height();
+  QPixmap warning_icon = QPixmap(":/ecalicons/WARNING").scaled(label_height, label_height, Qt::AspectRatioMode::KeepAspectRatio, Qt::TransformationMode::SmoothTransformation);
+  ui_.publish_timestamp_warning_label->setPixmap(warning_icon);
+  ui_.publish_timestamp_warning_label->setVisible(false);
+
+  // Setup frame
+  QFrame* frame = new QFrame(this);
+  frame->setFrameShape(QFrame::StyledPanel);
+  frame->setFrameStyle(QFrame::Plain);
+  QLayout* frame_layout = new QVBoxLayout(this);
+  frame_layout->setContentsMargins(QMargins(0, 0, 0, 0));
+  frame->setLayout(frame_layout);
+
+  size_label_ = new QLabel(this);
+  size_label_->setText("-- No messages received, yet --");
+  frame_layout->addWidget(size_label_);
+
+  blob_text_edit_ = new QPlainTextEdit(this);
+  blob_text_edit_->setFont(QFont("Courier New"));
+  blob_text_edit_->setReadOnly(true);
+  frame_layout->addWidget(blob_text_edit_);
+
+  ui_.content_layout->addWidget(frame);
+
+  // Connect the eCAL Subscriber
+  subscriber_.AddReceiveCallback(std::bind(&PluginWidget::ecalMessageReceivedCallback, this, std::placeholders::_2));
+}
+
+void PluginWidget::ecalMessageReceivedCallback(const struct eCAL::SReceiveCallbackData* callback_data)
+{
+  std::lock_guard<std::mutex> message_lock(message_mutex_);
+  last_message_ = QByteArray(static_cast<char*>(callback_data->buf), callback_data->size);
+
+  last_message_publish_timestamp_ = eCAL::Time::ecal_clock::time_point(std::chrono::microseconds(callback_data->time));
+
+  received_message_counter_++;
+  new_msg_available_ = true;
+}
+
+void PluginWidget::updatePublishTimeLabel()
+{
+  eCAL::Time::ecal_clock::time_point publish_time = last_message_publish_timestamp_;
+  eCAL::Time::ecal_clock::time_point receive_time = eCAL::Time::ecal_clock::now();
+
+  if (publish_time < eCAL::Time::ecal_clock::time_point(eCAL::Time::ecal_clock::duration(0)))
+    return;
+
+  auto diff = receive_time - publish_time;
+
+  if ((diff > std::chrono::milliseconds(100))
+    || (diff < std::chrono::milliseconds(-100)))
+  {
+    ui_.publish_timestamp_warning_label->setVisible(true);
+    QString diff_string = QString::number(std::chrono::duration_cast<std::chrono::duration<double>>(diff).count(), 'f', 6);
+    ui_.publish_timestamp_warning_label->setToolTip(tr("The publisher is not synchronized, properly.\nCurrent time difference: ") + diff_string + " s");
+  }
+  else
+  {
+    ui_.publish_timestamp_warning_label->setVisible(false);
+  }
+
+  QString time_string;
+
+  //if (parse_time_)
+  //{
+  //  QDateTime q_ecal_time = QDateTime::fromMSecsSinceEpoch(std::chrono::duration_cast<std::chrono::milliseconds>(publish_time.time_since_epoch()).count()).toUTC();
+  //  time_string = q_ecal_time.toString("yyyy-MM-dd HH:mm:ss.zzz");
+  //}
+  //else
+  {
+    double seconds_since_epoch = std::chrono::duration_cast<std::chrono::duration<double>>(publish_time.time_since_epoch()).count();
+    time_string = QString::number(seconds_since_epoch, 'f', 6) + " s";
+  }
+
+  ui_.publish_timestamp_label->setText(time_string);
+}
+
+PluginWidget::~PluginWidget()
+{
+}
+
+void PluginWidget::onUpdate()
+{
+  if (new_msg_available_)
+  {
+    updateRos2MessageView();
+    updatePublishTimeLabel();
+    ui_.received_message_counter_label->setText(QString::number(received_message_counter_));
+  }
+}
+
+void PluginWidget::onResume()
+{
+  subscriber_.AddReceiveCallback(std::bind(&PluginWidget::ecalMessageReceivedCallback, this, std::placeholders::_2));
+}
+
+void PluginWidget::onPause()
+{
+  subscriber_.RemReceiveCallback();
+}
+
+void PluginWidget::updateRos2MessageView()
+{
+  std::lock_guard<std::mutex> message_lock(message_mutex_);
+
+  quint16 crc16 = qChecksum(last_message_.data(), last_message_.length());
+  QString crc16_string = QString("%1").arg(QString::number(crc16, 16).toUpper(), 4, '0');
+  QString size_text = tr("Binary data of ") + QString::number(last_message_.size()) + tr(" bytes (CRC16: ") + crc16_string + ")";
+
+  size_label_->setText(size_text);
+
+  QByteArray last_message_trimmed(last_message_.data(), std::min(last_message_.length(), 1024));
+
+  // string is a special case
+  // use bounded string and array
+  if(topic_type_ == "std_msgs/msg/String")
+  {
+    std_msgs::msg::String msg;
+    msg.data.resize(last_message_trimmed.size());
+    memcpy((char*)msg.data.data(), (char*)last_message_trimmed.data(), last_message_trimmed.size());
+    blob_text_edit_->setPlainText(QString::fromStdString(to_yaml(msg)));
+  }
+  else
+  if(topic_type_ == "geometry_msgs/msg/Twist")
+  {
+    geometry_msgs::msg::Twist::RawPtr msg;
+    msg = reinterpret_cast<geometry_msgs::msg::Twist*>(last_message_trimmed.data());
+    blob_text_edit_->setPlainText(QString::fromStdString(to_yaml(*msg)));
+  }
+  else
+  {
+    blob_text_edit_->setPlainText("Msg Type Not Supported, Please Contact Zhensheng.");
+  }
+
+
+//   blob_text_edit_->setPlainText(
+// #if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+//     bytesToHex(last_message_trimmed, ' ')
+// #else //QT_VERSION
+//     last_message_trimmed.toHex(' ')
+// #endif // QT_VERSION
+//     + (last_message_trimmed.length() < last_message_.length() ? QString("...") : QString())
+//   );
+
+  new_msg_available_ = false;
+}
+
+QWidget* PluginWidget::getWidget()
+{
+  return this;
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+QString PluginWidget::bytesToHex(const QByteArray& byte_array, char separator)
+{
+  QString hex_string;
+  hex_string.reserve(byte_array.size() * 2 + (separator ? byte_array.size() : 0));
+
+  for (int i = 0; i < byte_array.size(); i++)
+  {
+    QByteArray temp_array;
+    temp_array.push_back(byte_array[i]);
+    hex_string += temp_array.toHex();
+    if (separator)
+    {
+      hex_string += separator;
+    }
+  }
+  return hex_string;
+}
+#endif //QT_VERSION

--- a/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.h
+++ b/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.h
@@ -1,0 +1,73 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/mon/plugin.h>
+#include <ecal/ecal.h>
+
+#include "ui_plugin_widget.h"
+
+#include <QPlainTextEdit>
+#include <QLabel>
+
+#include <mutex>
+
+class PluginWidget : public QWidget, public eCAL::mon::PluginWidgetInterface
+{
+  Q_OBJECT
+public:
+  PluginWidget(const QString& topic_name, const QString& topic_type, QWidget* parent = Q_NULLPTR);
+  virtual ~PluginWidget();
+
+  virtual QWidget* getWidget();
+
+public slots:
+  virtual void onUpdate();
+
+  virtual void onResume();
+  virtual void onPause();
+
+protected:
+  Ui::PluginWidget ui_;
+
+private slots:
+  void updateRos2MessageView();
+  void updatePublishTimeLabel();
+
+private:
+  QLabel*         size_label_;
+  QPlainTextEdit* blob_text_edit_;
+
+  eCAL::CSubscriber                  subscriber_;
+  QByteArray                         last_message_;
+  eCAL::Time::ecal_clock::time_point last_message_publish_timestamp_;
+  std::mutex                         message_mutex_;
+
+  QString                            topic_name_, topic_type_;
+
+  bool                               new_msg_available_;
+  int                                received_message_counter_;
+
+  void ecalMessageReceivedCallback(const struct eCAL::SReceiveCallbackData* callback_data);
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 9, 0)
+  static QString bytesToHex(const QByteArray& byte_array, char separator = '\0');
+#endif //QT_VERSION
+};

--- a/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.ui
+++ b/app/mon/mon_plugins/ros2_reflection/src/plugin_widget.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PluginWidget</class>
+ <widget class="QWidget" name="PluginWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>550</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>GroupWidget</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="content_layout"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="publish_timestamp_description_label">
+       <property name="minimumSize">
+        <size>
+         <width>10</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Publish timestamp:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="publish_timestamp_warning_label">
+       <property name="text">
+        <string>WARNING</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="publish_timestamp_label">
+       <property name="minimumSize">
+        <size>
+         <width>10</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>-</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="received_messages_label">
+       <property name="minimumSize">
+        <size>
+         <width>10</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Received messages: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="received_message_counter_label">
+       <property name="minimumSize">
+        <size>
+         <width>10</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../../../iconset/ecalicons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -288,6 +288,13 @@ namespace eCAL
     bool IsSubscribed() const;
 
     /**
+     * @brief Query the number of subscribers. 
+     *
+     * @return  Number of subscribers. 
+    **/
+    size_t GetSubscriberCount() const;
+
+    /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -219,6 +219,13 @@ namespace eCAL
     bool IsCreated() const {return(m_created);}
 
     /**
+     * @brief Query the number of publishers. 
+     *
+     * @return  Number of publishers. 
+    **/
+    size_t GetPublisherCount() const;
+
+    /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -324,6 +324,12 @@ namespace eCAL
     return(m_datawriter->IsSubscribed());
   }
 
+  size_t CPublisher::GetSubscriberCount() const
+  {
+    if(!m_datawriter) return(0);
+    return(m_datawriter->GetSubscriberCount());
+  }
+
   std::string CPublisher::GetTopicName() const
   {
     if(!m_datawriter) return("");

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -216,6 +216,12 @@ namespace eCAL
     return(m_datareader->RemEventCallback(type_));
   }
 
+  size_t CSubscriber::GetPublisherCount() const
+  {
+    if(!m_datareader) return(0);
+    return(m_datareader->GetPublisherCount());
+  }
+
   std::string CSubscriber::GetTopicName() const
   {
     if(!m_datareader) return("");

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -81,6 +81,12 @@ namespace eCAL
 
     bool IsCreated() const {return(m_created);}
 
+    size_t GetPublisherCount() const
+    {
+      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      return(m_loc_pub_map.size() + m_ext_pub_map.size());
+    }
+
     const std::string GetTopicName()   const {return(m_topic_name);}
     const std::string GetTopicID()     const {return(m_topic_id);}
     const std::string GetTypeName()    const {return(m_topic_type);}
@@ -113,7 +119,7 @@ namespace eCAL
 
     std::atomic<bool>                         m_connected;
     typedef Util::CExpMap<std::string, bool> ConnectedMapT;
-    std::mutex                                m_pub_map_sync;
+    mutable std::mutex                        m_pub_map_sync;
     ConnectedMapT                             m_loc_pub_map;
     ConnectedMapT                             m_ext_pub_map;
 

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -87,6 +87,11 @@ namespace eCAL
     bool IsCreated() const {return(m_created);}
     bool IsSubscribed() const {return(m_loc_subscribed || m_ext_subscribed);}
     bool IsExtSubscribed() const {return(m_ext_subscribed);}
+    size_t GetSubscriberCount() const
+    {
+      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      return(m_loc_sub_map.size() + m_ext_sub_map.size());
+    }
 
     const std::string& GetTopicName() const {return(m_topic_name);}
     const std::string& GetTopicID() const {return(m_topic_id);}
@@ -124,7 +129,7 @@ namespace eCAL
 
     std::atomic<bool>  m_connected;
     typedef Util::CExpMap<std::string, bool> ConnectedMapT;
-    std::mutex         m_sub_map_sync;
+    mutable std::mutex  m_sub_map_sync;
     ConnectedMapT      m_loc_sub_map;
     ConnectedMapT      m_ext_sub_map;
 


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request for this project
title: Add ros2 msg reflection plugin to ecal_mon_gui
labels: ''
assignees: ''

---

**Pull request type**

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**

Issue Number:  https://github.com/continental/rmw_ecal/issues/18#issue-929783852

- The ecal app tool does not have a good support to ros2 system.
- rmw_ecal_dynamic_cpp does not support ros2cli like `ros2 topic echo`
- 

**What is the new behavior?**

- You can view some ros2 msgs through ecal_mon_gui
- It can be a tool that replaces `ros2 topic echo`

![image](https://user-images.githubusercontent.com/17764118/127296262-6f3d299e-72e8-4623-8c03-ffaadc9c02fa.png)


**Does this introduce a breaking change?**

- [x] Yes
- [ ] No

**Other information**

As for now, it is still a demo case and may not be merged into the official repo.

Feel free to give me feedback. 

Thanks.
