### PR TITLE
Doc: Improved Hello World CMakeLists.txt

### DIFF
--- a/doc/rst/getting_started/hello_world.rst
+++ b/doc/rst/getting_started/hello_world.rst
@@ -58,17 +58,20 @@ Somewhere on your hard drive create an empty directory and create a file :file:`
   .. note::
      **What is happening here?**
 
-     **Line 3** creates a project "hello_world_snd".
-     This will also be the name of the executable (**line 14**).
+     **Line 2** makes CMake prefer installed config files instead of generic find scripts.
+     This is important for Windows, where eCAL installs Protobuf, HDF5 etc.
 
-     **Line 5-6** set the C++ standard to C++14
+     **Line 4** creates a project "hello_world_snd".
+     This will also be the name of the executable (**line 15**).
 
-     **Line 8** tells CMake to find the eCAL installation. **Line 16-18** will link the executable against it.
+     **Line 6-7** set the C++ standard to C++14
 
-     **Line 10-12** create a list of all our source files, which currently only contains :file:`main.cpp`.
-     We add that source file for compiling our executable in **line 14**.
+     **Line 9** tells CMake to find the eCAL installation. **Line 17-19** will link the executable against it.
 
-     **Line 16-18** link our executable against the eCAL core library.
+     **Line 11-13** create a list of all our source files, which currently only contains :file:`main.cpp`.
+     We add that source file for compiling our executable in **line 15**.
+
+     **Line 17-19** link our executable against the eCAL core library.
 
 * |fa-file-alt| :file:`main.cpp`:
 
@@ -141,7 +144,7 @@ Again, create a new directory somewhere and add create the :file:`CMakeLists.txt
   .. note::
      **What is happening here?**
 
-     **Line 3** creates a project "hello_world_rec".
+     **Line 4** creates a project "hello_world_rec".
      This is the only difference to the hello_world_snd Project.
 
 * |fa-file-alt| :file:`main.cpp`:

--- a/doc/rst/getting_started/hello_world_proto.rst
+++ b/doc/rst/getting_started/hello_world_proto.rst
@@ -67,11 +67,11 @@ Now start implementing the actual sender application. Just as in the :ref:`last 
   .. note::
      **What is happening here?**
 
-     **Line 14** adds Protobuf as dependency
+     **Line 10** adds Protobuf as dependency
      
-     **Line 20-22** Creates a list of .proto files. We only have one.
+     **Line 16-18** Creates a list of .proto files. We only have one.
 
-     **Line 26** Compiles the .proto file to a C++ header file (:file:`hello_world.pb.h`).
+     **Line 22** Compiles the .proto file to a C++ header file (:file:`hello_world.pb.h`).
      The ``PROTOBUF_TARGET_CPP`` function is a convenience function from eCAL.
      If you have already worked with Protobuf and CMake, you may be more familiar with the following code, which basically does the same thing:
 
@@ -81,7 +81,7 @@ Now start implementing the actual sender application. Just as in the :ref:`last 
        protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${protobuf_files})
        add_executable(${PROJECT_NAME} ${source_files} ${PROTO_SRCS} ${PROTO_HDRS}) 
 
-     **Line 30** links the executable against protobuf
+     **Line 26** links the executable against protobuf
 
 * |fa-file-alt| :file:`main.cpp`:
 

--- a/doc/rst/getting_started/src/hello_world/hello_world_rec/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world/hello_world_rec/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(hello_world_rec)
 

--- a/doc/rst/getting_started/src/hello_world/hello_world_snd/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world/hello_world_snd/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(hello_world_snd)
 

--- a/doc/rst/getting_started/src/hello_world_protobuf/protobuf_rec/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world_protobuf/protobuf_rec/CMakeLists.txt
@@ -1,14 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(protobuf_rec)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-if(MSVC)
-  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
-  set (Protobuf_USE_STATIC_LIBS TRUE) 
-endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/doc/rst/getting_started/src/hello_world_protobuf/protobuf_snd/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world_protobuf/protobuf_snd/CMakeLists.txt
@@ -1,14 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(protobuf_snd)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-if(MSVC)
-  # CMake >= 3.15 will erroneously define PROTOBUF_USE_DLLS otherwise
-  set (Protobuf_USE_STATIC_LIBS TRUE) 
-endif()
 
 find_package(eCAL REQUIRED)
 find_package(Protobuf REQUIRED)


### PR DESCRIPTION
Removed the old PROTOBUF_USE_DLL with set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON), so CMake will properly use the installed protobuf config instead of the generic find script.