### PR TITLE
fixed issue #397, in case of empty protobuf messages (defaults only) …

### DIFF
--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -136,11 +136,24 @@ namespace eCAL
       **/
       size_t GetSize(const T& msg_) const
       {
+        size_t size(0);
 #if GOOGLE_PROTOBUF_VERSION >= 3001000
-        return((size_t)msg_.ByteSizeLong());
+        size = (size_t)msg_.ByteSizeLong();
 #else
-        return((size_t)msg_.ByteSize());
+        size = (size_t)msg_.ByteSize();
 #endif
+        // In case we have an empty protocol buffer message object
+        // (containing default values only) the serialized size
+        // will be zero and the message will not be transported by
+        // any layer.
+        // We increase message size to 1 byte to force transport.
+        // protobuf::CSubscriber::Deserialize will check this and
+        // return an empty message object as expected.
+        if (size == 0)
+        {
+          size = 1;
+        }
+        return(size);
       }
 
       /**

--- a/ecal/core/include/ecal/msg/protobuf/subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/subscriber.h
@@ -139,7 +139,26 @@ namespace eCAL
       **/
       bool Deserialize(T& msg_, const void* buffer_, size_t size_) const
       {
-        return(msg_.ParseFromArray(buffer_, static_cast<int>(size_)));
+        // we try to parse the message from the received buffer
+        if (msg_.ParseFromArray(buffer_, static_cast<int>(size_)))
+        {
+          return(true);
+        }
+        else
+        {
+          // If deserialization failed we check for message size.
+          // Empty messages will set to a minimum size of 1 byte
+          // by the protobuf::CPublisher::GetSize function to force
+          // the transport through all layers.
+          // In this case we clear the message object and 
+          // return success.
+          if (size_ == 1)
+          {
+            msg_.Clear();
+            return(true);
+          }
+        }
+        return(false);
       }
 
     };


### PR DESCRIPTION
…transport will be forced with a minimal message of 1 byte

**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

Issue Number: Fixing issue #397 

**What is the new behavior?**
Empty protobuf messages will be transported as a single byte size message.