### PR TITLE
Dynamic Subscriber - check for default (empty) proto

### DIFF
--- a/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -295,7 +295,22 @@ namespace eCAL
           }
           else
           {
-            throw DynamicReflectionException("CDynamicSubscriber: DataContent could not be parsed");
+            // If deserialization failed we check for message size.
+            // Empty messages will set to a minimum size of 1 byte
+            // by the protobuf::CPublisher::GetSize function to force
+            // the transport through all layers.
+            // In this case we clear the message object and
+            // return success.
+            if (data_->size == 1)
+            {
+              msg_ptr->Clear();
+              msg_callback(topic_name_, *msg_ptr, data_->time);
+            }
+            else
+            {
+              throw DynamicReflectionException("CDynamicSubscriber: DataContent could not be parsed");
+            }
+
           }
         }
       }


### PR DESCRIPTION
Recently support for handling default (zero-byte) protobuf messages was fixed in v5.9.1. Logic was placed in `subscriber.h` to handle this new case. However, the logic to handle it in `dynamic_subscriber.h` was also missing. This PR adds that logic.

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
The dynamic subscriber callback doesn't get called when default (empty) proto messages are published.

Issue Number: https://github.com/continental/ecal/issues/397

**What is the new behavior?**
The dynamic subscriber callback does get called with a default message when a default (empty) proto message is published.

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No

**Other information**
I issued this PR against the `support/v5.9` branch, and I'm not sure if that's the correct process, so please let me know.