### PR TITLE
disable documentation build on macos

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,7 +55,7 @@ jobs:
         -DHAS_QT5=ON \
         -DHAS_CURL=ON \
         -DHAS_CAPNPROTO=ON \
-        -DBUILD_DOCS=ON \
+        -DBUILD_DOCS=OFF \
         -DBUILD_APPS=ON \
         -DBUILD_SAMPLES=ON \
         -DBUILD_TIME=ON \


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 
