### PR TITLE
doxygen downgrade to 1.9.2 because of chocolatey install checksum error

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,7 +26,8 @@ jobs:
         nuget-version: '5.8.x'
         
     - name: Install Dependencies
-      run: choco install doxygen.install
+      # choco install of version 1.9.3 produced a checksum error
+      run: choco install doxygen.install --version=1.9.2
 
     - name: Uninstall Chocolatey
       run: move "$env:PROGRAMDATA\chocolatey" "$env:PROGRAMDATA\_chocolatey"


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Windows GitHub action does not work because of checksum error while installing doxygen via chocolatey

```
Download of doxygen-1.9.3-setup.exe (41.22 MB) completed.
Error - hashes do not match. Actual value was '83F7241DFB44C5BB271072792379BCB539284247'.
ERROR: Checksum for 'C:\Users\runneradmin\AppData\Local\Temp\chocolatey\doxygen.install\1.9.3\doxygen-1.9.3-setup.exe' did not meet '24fd29b4476ad1197a41438efcd67b926db923cd' for checksum type 'sha1'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.

The install of doxygen.install was NOT successful.
```
Issue Number: N/A

**What is the new behavior?**
By downgrading doxygen to version 1.9.2, the issue is fixed for now.