### PR TITLE
[CMake]: Fixed build issues with old CMake versions

### DIFF
--- a/thirdparty/build-recycle.cmake
+++ b/thirdparty/build-recycle.cmake
@@ -1,3 +1,2 @@
 add_subdirectory(thirdparty/recycle EXCLUDE_FROM_ALL)
-set_property(TARGET recycle PROPERTY FOLDER lib/recycle)
 add_library(steinwurf::recycle ALIAS recycle)


### PR DESCRIPTION
Removed FOLDER property of the recycle submodule. The Property wouldn't do anything anyways. In CMake < 3.19 setting the FOLDER property to interface targets would create a failure, while recent versions >= 3.19 would just ignore it.
