### PR TITLE
Feature/player status rpc query

### DIFF
--- a/app/play/play_cli/src/ecal_play_service.h
+++ b/app/play/play_cli/src/ecal_play_service.h
@@ -53,6 +53,11 @@ public:
                         , ::eCAL::pb::play::Response*               response
                         , ::google::protobuf::Closure*              done);
 
+  virtual void GetState(::google::protobuf::RpcController*          controller,
+                        const ::eCAL::pb::play::Empty*              request,
+                        ::eCAL::pb::play::State*                    response,
+                        ::google::protobuf::Closure*                done);
+
   bool IsExitRequested() const;
 
 private:

--- a/app/play/play_gui/src/ecal_play_service.h
+++ b/app/play/play_gui/src/ecal_play_service.h
@@ -49,6 +49,11 @@ public:
                         , ::eCAL::pb::play::Response*               response
                         , ::google::protobuf::Closure*              done);
 
+  virtual void GetState(::google::protobuf::RpcController*          controller,
+                        const ::eCAL::pb::play::Empty*              request,
+                        ::eCAL::pb::play::State*                    response,
+                        ::google::protobuf::Closure*                done);
+
 private:
   static bool strToBool(const std::string& str);
 };

--- a/ecal/pb/src/ecal/pb/play/service.proto
+++ b/ecal/pb/src/ecal/pb/play/service.proto
@@ -19,6 +19,8 @@
 
 syntax = "proto3";
 
+import "ecal/pb/play/state.proto";
+
 option cc_generic_services = true;
 
 package eCAL.pb.play;
@@ -90,9 +92,12 @@ message Response                         // common player service response
   string                   error  =  2;  // human readable error message
 }
 
+message Empty {}
+
 service EcalPlayService
 {
   rpc GetConfig  (GetConfigRequest) returns (GetConfigResponse);  // get current configuration
   rpc SetConfig  (SetConfigRequest) returns (Response);           // set configuration
   rpc SetCommand (CommandRequest)   returns (Response);           // set recorder command
+  rpc GetState (Empty) returns (State);           // set current playback status
 }

--- a/samples/cpp/services/ecalplayer_client/src/ecalplayer_client.cpp
+++ b/samples/cpp/services/ecalplayer_client/src/ecalplayer_client.cpp
@@ -48,12 +48,23 @@ void OnPlayerResponse(const struct eCAL::SServiceInfo& service_info_, const std:
       std::cout << "PlayerService " << service_info_.method_name << " called successfully on host " << service_info_.host_name << std::endl;
       std::cout << response.DebugString();
     }
-    else
+    else if (service_info_.method_name == "Response")
     {
       eCAL::pb::play::Response response;
       response.ParseFromString(response_);
       std::cout << "PlayerService " << service_info_.method_name << " called successfully on host " << service_info_.host_name << std::endl;
       std::cout << response.DebugString();
+    }
+    else if (service_info_.method_name == "GetState")
+    {
+        eCAL::pb::play::State response;
+        response.ParseFromString(response_);
+        std::cout << "PlayerService " << service_info_.method_name << " called successfully on host " << service_info_.host_name << std::endl;
+        std::cout << response.DebugString();
+    }
+    else
+    {
+        std::cout << "PlayerService " << service_info_.method_name << " received unknown message on host " << service_info_.host_name << std::endl;
     }
   }
   break;
@@ -120,6 +131,9 @@ int main(int argc, char **argv)
 
     player_service.Call("SetConfig", set_config_request);
     std::cout << set_config_request.DebugString() << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+    player_service.Call("GetState", eCAL::pb::play::Empty());
     std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
     ////////////////////////////////////


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Currently if an ecal user wants to query the playback state of the player, it has to wait for the periodic state updates

Issue Number: N/A

**What is the new behavior?**
Added a GetState service method to the Player, so playback state can be actively queried instead of waiting for the periodic state update. Works with both GUI and CLI players.


**Does this introduce a breaking change?**

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
