### PR TITLE
Fix: shared_lock for publisher, subscriber and description gate

### DIFF
--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -42,7 +42,7 @@ namespace eCAL
 
   void CDescGate::ApplyDescription(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_)
   {
-    std::lock_guard<std::mutex> lock(m_topic_name_desc_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
     TopicNameDescMapT::iterator iter = m_topic_name_desc_map.find(topic_name_);
     
     // new element (no need to check anything, just add it)
@@ -104,7 +104,7 @@ namespace eCAL
   {
     if(topic_name_.empty()) return(false);
 
-    std::lock_guard<std::mutex> lock(m_topic_name_desc_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
     TopicNameDescMapT::iterator iter = m_topic_name_desc_map.find(topic_name_);
 
     if(iter == m_topic_name_desc_map.end()) return(false);
@@ -116,7 +116,7 @@ namespace eCAL
   {
     if(topic_name_.empty()) return(false);
 
-    std::lock_guard<std::mutex> lock(m_topic_name_desc_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
     TopicNameDescMapT::iterator iter = m_topic_name_desc_map.find(topic_name_);
 
     if(iter == m_topic_name_desc_map.end()) return(false);

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -26,7 +26,7 @@
 #include "ecal_global_accessors.h"
 #include "ecal_def.h"
 
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <map>
 #include <memory>
@@ -69,7 +69,7 @@ namespace eCAL
     };
 
     typedef std::map<std::string, STypeDesc> TopicNameDescMapT;
-    std::mutex        m_topic_name_desc_sync;
-    TopicNameDescMapT m_topic_name_desc_map;
+    std::shared_timed_mutex  m_topic_name_desc_sync;
+    TopicNameDescMapT        m_topic_name_desc_map;
   };
 };

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -60,8 +60,8 @@ namespace eCAL
   {
     if(!m_created) return;
 
-    // destroy all undestroyed publisher
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    // destroy all remaining publisher
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     for (auto iter = m_topic_name_datawriter_map.begin(); iter != m_topic_name_datawriter_map.end(); ++iter)
     {
       iter->second->Destroy();
@@ -85,7 +85,7 @@ namespace eCAL
     if(!m_created) return(false);
 
     // register writer and multicast group
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     m_topic_name_datawriter_map.emplace(std::pair<std::string, CDataWriter*>(topic_name_, datawriter_));
 
     return(true);
@@ -96,7 +96,7 @@ namespace eCAL
     if(!m_created) return(false);
     bool ret_state = false;
 
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     auto res = m_topic_name_datawriter_map.equal_range(topic_name_);
     for(TopicNameDataWriterMapT::iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -139,7 +139,7 @@ namespace eCAL
     }
 
     // register local subscriber
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     auto res = m_topic_name_datawriter_map.equal_range(topic_name);
     for(TopicNameDataWriterMapT::const_iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -173,7 +173,7 @@ namespace eCAL
     }
 
     // register external subscriber
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     auto res = m_topic_name_datawriter_map.equal_range(topic_name);
     for(TopicNameDataWriterMapT::const_iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -186,7 +186,7 @@ namespace eCAL
     if (!m_created) return;
 
     // refresh publisher registrations
-    std::lock_guard<std::mutex> lock(m_topic_name_datawriter_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
     for (auto iter : m_topic_name_datawriter_map)
     {
       iter.second->RefreshRegistration();

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -28,7 +28,7 @@
 
 #include "readwrite/ecal_writer.h"
 
-#include <mutex>
+#include <shared_mutex>
 #include <atomic>
 #include <unordered_map>
 
@@ -64,7 +64,7 @@ namespace eCAL
     bool                      m_share_desc;
 
     typedef std::multimap<std::string, CDataWriter*> TopicNameDataWriterMapT;
-    std::mutex                m_topic_name_datawriter_sync;
+    std::shared_timed_mutex   m_topic_name_datawriter_sync;
     TopicNameDataWriterMapT   m_topic_name_datawriter_map;
   };
 };

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -84,7 +84,7 @@ namespace eCAL
     m_subtimeout_thread.Stop();
 
     // destroy all remaining subscriber
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     for (auto iter = m_topic_name_datareader_map.begin(); iter != m_topic_name_datareader_map.end(); ++iter)
     {
       iter->second->Destroy();
@@ -98,7 +98,7 @@ namespace eCAL
     if(!m_created) return(false);
 
     // register reader
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     m_topic_name_datareader_map.emplace(std::pair<std::string, CDataReader*>(topic_name_, datareader_));
 
     return(true);
@@ -109,7 +109,7 @@ namespace eCAL
     if(!m_created) return(false);
     bool ret_state = false;
 
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     auto res = m_topic_name_datareader_map.equal_range(topic_name_);
     for(TopicNameDataReaderMapT::iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -125,7 +125,7 @@ namespace eCAL
 
   bool CSubGate::HasSample(const std::string& sample_name_)
   {
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     return(m_topic_name_datareader_map.find(sample_name_) != m_topic_name_datareader_map.end());
   }
 
@@ -153,8 +153,8 @@ namespace eCAL
       auto& ecal_sample_content_payload = ecal_sample_content.payload();
       g_process_rbytes_sum += ecal_sample_.content().payload().size();
 
-      // add sample to data reader
-      std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+      // apply sample to data reader
+      std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
       auto res = m_topic_name_datareader_map.equal_range(ecal_sample_.topic().tname());
       for (auto it = res.first; it != res.second; ++it)
       {
@@ -186,9 +186,9 @@ namespace eCAL
     g_process_rclock++;
     g_process_rbytes_sum += len_;
 
-    // add sample to data reader
+    // apply sample to data reader
     size_t sent(0);
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     auto res = m_topic_name_datareader_map.equal_range(topic_name_);
     for (auto it = res.first; it != res.second; ++it)
     {
@@ -214,7 +214,7 @@ namespace eCAL
     std::string process_id = std::to_string(ecal_sample_.topic().pid());
 
     // handle local publisher connection
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     auto res = m_topic_name_datareader_map.equal_range(topic_name);
     for (TopicNameDataReaderMapT::iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -234,7 +234,7 @@ namespace eCAL
         //    later check in ecal_reader_shm SetConnectionParameter()
         // ---------------------------------------------------------------
 
-        // first check for new behaviour
+        // first check for new behavior
         std::string writer_par = tlayer.par_layer().SerializeAsString();
 
         // ----------------------------------------------------------------------
@@ -269,7 +269,7 @@ namespace eCAL
     if (g_descgate()) g_descgate()->ApplyDescription(topic_name, sample_topic.ttype(), sample_topic.tdesc());
 
     // handle external publisher connection
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     auto res = m_topic_name_datareader_map.equal_range(topic_name);
     for (TopicNameDataReaderMapT::iterator iter = res.first; iter != res.second; ++iter)
     {
@@ -292,7 +292,7 @@ namespace eCAL
     if (!m_created) return;
 
     // refresh reader registrations
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     for (auto iter : m_topic_name_datareader_map)
     {
       iter.second->RefreshRegistration();
@@ -304,7 +304,7 @@ namespace eCAL
     if (!m_created) return(0);
 
     // check subscriber timeouts
-    std::lock_guard<std::mutex> lock(m_topic_name_datareader_sync);
+    std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
     for (auto iter = m_topic_name_datareader_map.begin(); iter != m_topic_name_datareader_map.end(); ++iter)
     {
       iter->second->CheckReceiveTimeout();

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -28,7 +28,7 @@
 #include "readwrite/ecal_reader.h"
 
 #include <atomic>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 
@@ -60,13 +60,8 @@ namespace eCAL
 
     // database data reader
     typedef std::unordered_multimap<std::string, CDataReader*> TopicNameDataReaderMapT;
-    std::mutex               m_topic_name_datareader_sync;
+    std::shared_timed_mutex  m_topic_name_datareader_sync;
     TopicNameDataReaderMapT  m_topic_name_datareader_map;
-
-    // database topics
-    typedef std::map<std::string, std::string> TopicNameDescMapT;
-    std::mutex               m_topic_name_desc_sync;
-    TopicNameDescMapT        m_topic_name_desc_map;
 
     eCAL::CThread            m_subtimeout_thread;
     int CheckTimeouts();


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Multiple subscriber callback are called synchronously. Access is locked by standard (exclusive) mutex. This may lead to performance issues.

Issue Number: #468 

**What is the new behavior?**
Subscriber callbacks are called asynchronously by using a shared lock. A single subscriber callback can not be called parallel (as before).

The same adaption (shared locking) is done for the description gate and may be done in the future for the client and service gates (after merging #372)