### PR TITLE
Fix: eCAL HDF5 Files - enable creation of bit-exact files

### DIFF
--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -344,6 +344,7 @@ bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const void* data, const unsigned lon
 
   //  Create creation property for dataSpace
   auto dsProperty = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(dsProperty, false);
 
   //  Create dataset in dataSpace
   auto dataSet = H5Dcreate(file_id_, std::to_string(entries_counter_).c_str(), H5T_NATIVE_UCHAR, dataSpace, H5P_DEFAULT, dsProperty, H5P_DEFAULT);
@@ -598,6 +599,7 @@ bool eCAL::eh5::HDF5MeasDir::CreateEntriesTableOfContentsFor(const std::string& 
 
   //  Create creation property for dataSpace
   auto dsProperty = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(dsProperty, false);
 
   auto dataSet = H5Dcreate(file_id_, channelName.c_str(), H5T_NATIVE_LLONG, dataSpace, H5P_DEFAULT, dsProperty, H5P_DEFAULT);
 


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Writing the exact same content into an eCAL HDF5 recording leads to none bit exact files because of an extra time stamp added by the HDF5 library.

Issue Number: #471

**What is the new behavior?**
Files are bit exact.