### PR TITLE
[Build]: Split CONFIG expressino to support legacy cmake <3.19

### DIFF
--- a/cmake/helper_functions/ecal_add_functions.cmake
+++ b/cmake/helper_functions/ecal_add_functions.cmake
@@ -81,7 +81,9 @@ function(ecal_add_mon_plugin TARGET_NAME)
   )
   target_compile_definitions(${TARGET_NAME}
     PRIVATE
-      $<$<CONFIG:Release,RelWithDebInfo,MinSizeRel>:QT_NO_DEBUG>
+      $<$<CONFIG:Release>:QT_NO_DEBUG>
+      $<$<CONFIG:RelWithDebInfo>:QT_NO_DEBUG>
+      $<$<CONFIG:MinSizeRel>:QT_NO_DEBUG>
   )
     
 endfunction()


### PR DESCRIPTION
Pre-3.19 cmake did not accept multiple values in a $<CONFIG:xxxx> expression.