### PR TITLE
Fix: setting service name independently from protobuf service name

### DIFF
--- a/ecal/core/include/ecal/msg/protobuf/client.h
+++ b/ecal/core/include/ecal/msg/protobuf/client.h
@@ -52,12 +52,22 @@ namespace eCAL
     {
     public:
       /**
-       * @brief Constructor.
+       * @brief Constructor (using protobuf defined service name).
        *
       **/
       CServiceClient()
       {
         Create(T::descriptor()->full_name());
+      }
+
+      /**
+       * @brief Constructor.
+       *
+       * @param service_name_  Unique service name.
+      **/
+      CServiceClient(const std::string& service_name_)
+      {
+        Create(service_name_);
       }
 
       /**

--- a/ecal/core/include/ecal/msg/protobuf/server.h
+++ b/ecal/core/include/ecal/msg/protobuf/server.h
@@ -71,6 +71,17 @@ namespace eCAL
       }
 
       /**
+       * @brief Constructor.
+       *
+       * @param service_       Google protobuf service instance.
+       * @param service_name_  Unique service name.
+      **/
+      CServiceServer(std::shared_ptr<T> service_, const std::string& service_name_) : m_service(nullptr)
+      {
+        Create(service_, service_name_);
+      }
+
+      /**
        * @brief Destructor.
       **/
       ~CServiceServer()
@@ -92,16 +103,24 @@ namespace eCAL
        * @brief Create service.
        *
        * @param service_  Google protobuf service instance.
+       * @param service_name_  Unique service name.
        *
        * @return  True if successful.
       **/
-      bool Create(std::shared_ptr<T> service_)
+      bool Create(std::shared_ptr<T> service_, const std::string& service_name_ = "")
       {
         if (service_ == nullptr) return false;
         m_service = service_;
 
         const google::protobuf::ServiceDescriptor* service_descriptor = service_->GetDescriptor();
-        Create(service_descriptor->full_name());
+        if (service_name_.empty())
+        {
+          Create(service_descriptor->full_name());
+        }
+        else
+        {
+          Create(service_name_);
+        }
 
         for (int i = 0; i < service_descriptor->method_count(); ++i)
         {

--- a/samples/cpp/services/ping_client/src/ping_client.cpp
+++ b/samples/cpp/services/ping_client/src/ping_client.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
   eCAL::Initialize(argc, argv, "ping client");
 
   // create ping service client
-  eCAL::protobuf::CServiceClient<PingService> ping_client;
+  eCAL::protobuf::CServiceClient<PingService> ping_client("ping service");
 
   // waiting for service
   while (!ping_client.IsConnected())

--- a/samples/cpp/services/ping_server/src/ping_server.cpp
+++ b/samples/cpp/services/ping_server/src/ping_server.cpp
@@ -48,8 +48,8 @@ int main(int argc, char **argv)
   eCAL::Initialize(argc, argv, "ping server");
 
   // create Ping service server
-  std::shared_ptr<PingService> ping_servive = std::make_shared<PingServiceImpl>();
-  eCAL::protobuf::CServiceServer<PingService> ping_server(ping_servive);
+  std::shared_ptr<PingService> ping_service = std::make_shared<PingServiceImpl>();
+  eCAL::protobuf::CServiceServer<PingService> ping_server(ping_service, "ping service");
 
   while(eCAL::Ok())
   {


### PR DESCRIPTION
… name)

**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Protobuf service instance name can not be set independently from the service name given by the protobuf service description.

Issue Number: #493

**What is the new behavior?**
Protobuf service instance name can be set independently.

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No
