### PR TITLE
Added dark mode to GUI Applications

### DIFF
--- a/app/mon/mon_gui/src/ecalmon.h
+++ b/app/mon/mon_gui/src/ecalmon.h
@@ -44,12 +44,22 @@
 class Ecalmon : public QMainWindow
 {
   Q_OBJECT
+private:
+  enum class Theme:int
+  {
+    Default,
+    Dark,
+  };
 
 public:
   Ecalmon(QWidget *parent = Q_NULLPTR);
 
   ~Ecalmon();
 
+protected:
+  void showEvent(QShowEvent *event) override;
+
+public:
   bool isMonitorUpdatePaused() const;
   bool isParseTimeEnabled() const;
 
@@ -59,6 +69,7 @@ public slots:
   void setMonitorUpdatePaused(bool paused);
   void setLogUpdatePaused(bool paused);
   void setParseTimeEnabled(bool enabled);
+  void setTheme(Theme theme);
 
   void resetLayout();
   
@@ -91,11 +102,16 @@ private:
 
   QActionGroup*  monitor_update_speed_group_;
   QActionGroup*  log_update_speed_group_;
+  QActionGroup*  theme_action_group_;
 
+  bool       first_show_event_;
   QByteArray initial_geometry_;
   QByteArray initial_state_;
   bool       initial_alternating_row_colors_;
   bool       initial_parse_time_;
+  QPalette   initial_palette_;
+  QStyle*    initial_style_;
+  QString    initial_style_sheet_;
 
   int monitor_error_counter_;
 

--- a/app/mon/mon_gui/src/main_window.ui
+++ b/app/mon/mon_gui/src/main_window.ui
@@ -75,7 +75,15 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="menu_theme">
+     <property name="title">
+      <string>&amp;Theme</string>
+     </property>
+     <addaction name="action_theme_default"/>
+     <addaction name="action_theme_dark"/>
+    </widget>
     <addaction name="action_reset_layout"/>
+    <addaction name="menu_theme"/>
     <addaction name="separator"/>
     <addaction name="action_alternating_row_colors"/>
     <addaction name="action_show_parsed_times"/>
@@ -538,7 +546,26 @@
   </action>
   <action name="action_npcap_status">
    <property name="text">
-    <string>Npcap status...</string>
+    <string>&amp;Npcap status...</string>
+   </property>
+  </action>
+  <action name="action_theme_default">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Default</string>
+   </property>
+  </action>
+  <action name="action_theme_dark">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dark</string>
    </property>
   </action>
  </widget>

--- a/app/play/play_gui/src/ecal_play_gui.h
+++ b/app/play/play_gui/src/ecal_play_gui.h
@@ -43,12 +43,20 @@ class EcalplayGui : public QMainWindow
 {
   Q_OBJECT
 
+private:
+  enum class Theme:int
+  {
+    Default,
+    Dark,
+  };
+
 public:
   EcalplayGui(QWidget *parent = Q_NULLPTR);
 
   ~EcalplayGui();
 
 protected:
+  void showEvent(QShowEvent *event) override;
   void closeEvent(QCloseEvent* event) override;
 
   void dragEnterEvent(QDragEnterEvent* event) override;
@@ -79,6 +87,7 @@ private slots:
   void updateScenariosModified();
 
   void resetLayout();
+  void setTheme(Theme theme);
 
   bool loadMeasurementFromFileDialog();
   bool loadMeasurement(const QString& path);
@@ -87,7 +96,10 @@ private slots:
 private:
   Ui::EcalplayMainWindow ui_;
 
+  bool       first_show_event_;
+
   QActionGroup* default_channel_mapping_action_group_;
+  QActionGroup*  theme_action_group_;
 
   bool play_pause_button_state_is_play_;
   bool connect_to_ecal_button_state_is_connect_;
@@ -108,6 +120,10 @@ private:
   QByteArray initial_geometry_;
   QByteArray initial_state_;
 
+  QPalette   initial_palette_;
+  QStyle*    initial_style_;
+  QString    initial_style_sheet_;
+
   void setPlayPauseActionToPlay();
   void setPlayPauseActionToPause();
 
@@ -125,9 +141,6 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 //// Windows specific                                                        ////
 ////////////////////////////////////////////////////////////////////////////////
-protected:
-  void showEvent(QShowEvent* event) override;
-
 private slots:
   void updateTaskbarProgress(const EcalPlayState& current_state);
   void showConsole(bool show);

--- a/app/play/play_gui/src/main_window.ui
+++ b/app/play/play_gui/src/main_window.ui
@@ -85,10 +85,18 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="menu_theme">
+     <property name="title">
+      <string>Theme</string>
+     </property>
+     <addaction name="action_theme_default"/>
+     <addaction name="action_theme_dark"/>
+    </widget>
     <addaction name="action_settings"/>
     <addaction name="action_debug_console"/>
     <addaction name="separator"/>
     <addaction name="action_reset_layout"/>
+    <addaction name="menu_theme"/>
    </widget>
    <widget class="QMenu" name="menu_windows">
     <property name="title">
@@ -527,6 +535,25 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="action_theme_default">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Default</string>
+   </property>
+  </action>
+  <action name="action_theme_dark">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dark</string>
    </property>
   </action>
  </widget>

--- a/app/rec/rec_gui/src/ecalrec_gui.h
+++ b/app/rec/rec_gui/src/ecalrec_gui.h
@@ -41,6 +41,12 @@
 class EcalRecGui : public QMainWindow
 {
   Q_OBJECT
+private:
+  enum class Theme:int
+  {
+    Default,
+    Dark,
+  };
 
 //////////////////////////////////////////
 // Constructor & Destructor
@@ -65,6 +71,9 @@ private:
 
 public slots:
   void resetLayout();
+
+private:
+  void setTheme(Theme theme);
 
 //////////////////////////////////////////
 // Private slots
@@ -124,12 +133,18 @@ private:
 
   QStringList recent_file_list_;
 
+  QActionGroup* theme_action_group_;
+
   // initial layout
   bool       first_show_event_;
   QByteArray initial_geometry_;
   QByteArray initial_state_;
   bool       initial_show_disabled_elements_at_the_bottom_;
   bool       initial_alternating_row_colors_;
+
+  QPalette   initial_palette_;
+  QStyle*    initial_style_;
+  QString    initial_style_sheet_;
 
 #ifdef WIN32
 ////////////////////////////////////////////

--- a/app/rec/rec_gui/src/main_window.ui
+++ b/app/rec/rec_gui/src/main_window.ui
@@ -24,7 +24,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QToolTipMenu" name="menu_file">
@@ -49,8 +49,16 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="menu_theme">
+     <property name="title">
+      <string>&amp;Theme</string>
+     </property>
+     <addaction name="action_theme_default"/>
+     <addaction name="action_theme_dark"/>
+    </widget>
     <addaction name="action_debug_console"/>
     <addaction name="action_reset_layout"/>
+    <addaction name="menu_theme"/>
     <addaction name="separator"/>
     <addaction name="action_show_disabled_elements_at_the_bottom"/>
     <addaction name="action_alternating_row_colors"/>
@@ -671,6 +679,25 @@
   <action name="action_rec_state_update_speed_0_05">
    <property name="text">
     <string>50 ms</string>
+   </property>
+  </action>
+  <action name="action_theme_default">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Default</string>
+   </property>
+  </action>
+  <action name="action_theme_dark">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dark</string>
    </property>
   </action>
  </widget>

--- a/app/sys/sys_gui/src/ecalsys_gui.h
+++ b/app/sys/sys_gui/src/ecalsys_gui.h
@@ -44,13 +44,26 @@ class EcalsysGui : public QMainWindow
 {
   Q_OBJECT
 
+private:
+  enum class Theme:int
+  {
+    Default,
+    Dark,
+  };
+
 public:
   EcalsysGui(QWidget *parent = Q_NULLPTR);
 
   ~EcalsysGui();
 
+protected:
+  void showEvent(QShowEvent *event) override;
+
+public:
   void saveGuiSettings();
   void loadGuiSettings();
+
+  void setTheme(Theme theme);
 
   void setUnmodified() { config_has_been_modified_ = false; };
 
@@ -64,6 +77,7 @@ protected:
 
 private:
   Ui::EcalsysMainWindow  ui_;
+  bool                   first_show_event_;
 
   QStringList last_config_list;
 
@@ -71,10 +85,15 @@ private:
   QByteArray             initial_geometry_;
   QByteArray             initial_state_;
 
+  QPalette               initial_palette_;
+  QStyle*                initial_style_;
+  QString                initial_style_sheet_;
 
   bool                   config_has_been_modified_;
   QActionGroup*          task_target_action_group_;
   QTimer*                button_update_timer_;
+
+  QActionGroup*          theme_action_group_;
 
   eCAL::protobuf::CServiceServer<eCAL::pb::sys::Service> ecalsys_service_;
 

--- a/app/sys/sys_gui/src/main_window.ui
+++ b/app/sys/sys_gui/src/main_window.ui
@@ -63,10 +63,18 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <widget class="QMenu" name="menu_theme">
+     <property name="title">
+      <string>&amp;Theme</string>
+     </property>
+     <addaction name="action_theme_default"/>
+     <addaction name="action_theme_dark"/>
+    </widget>
     <addaction name="action_view_runners"/>
     <addaction name="action_show_console"/>
     <addaction name="separator"/>
     <addaction name="action_view_reset_layout"/>
+    <addaction name="menu_theme"/>
    </widget>
    <widget class="QMenu" name="menu_options">
     <property name="title">
@@ -819,6 +827,25 @@
    </property>
    <property name="text">
     <string>&amp;Debug console...</string>
+   </property>
+  </action>
+  <action name="action_theme_default">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Defaukt</string>
+   </property>
+  </action>
+  <action name="action_theme_dark">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Dark</string>
    </property>
   </action>
  </widget>

--- a/lib/QEcalParser/src/ecal_parser_editor/ecal_parser_editor_widget.cpp
+++ b/lib/QEcalParser/src/ecal_parser_editor/ecal_parser_editor_widget.cpp
@@ -103,14 +103,17 @@ QString QEcalParserEditor::css()
 {
   return R"(
 #usage {
+    color: rgb(0,0,0);
     font-family: "Courier New", Courier, monospace;
     background-color: rgb(220,220,220);
 }
 #code {
+    color: rgb(0,0,0);
     font-family: "Courier New", Courier, monospace;
     background-color: rgb(220,220,220);
 }
 #example {
+    color: rgb(0,0,0);
     font-family: "Courier New", Courier, monospace;
     background-color: rgb(220,220,220);
     margin-left: 10px;


### PR DESCRIPTION
Added a dark mode that one can enable via `View/Theme` in all of our main GUI Applications.

![grafik](https://user-images.githubusercontent.com/11774314/151596270-2f91c6d1-bcd3-4a5b-b6bf-ceb9d3d06350.png)
