### PR TITLE
registration sleep logic cleanup (removal)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Install Qt

--- a/ecal/core/src/ecal_register.cpp
+++ b/ecal/core/src/ecal_register.cpp
@@ -162,7 +162,6 @@ namespace eCAL
     {
       RegisterProcess();
       RegisterSample(service_name_, ecal_sample_);
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     return(true);
@@ -247,7 +246,6 @@ namespace eCAL
 
     // register sample
     size_t sent_sum = RegisterSample(Process::GetHostName(), process_sample);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
     return(sent_sum);
   }
@@ -258,20 +256,11 @@ namespace eCAL
     if(!m_reg_services) return(0);
 
     size_t sent_sum(0);
-    int    sent_cnt(0);
     std::lock_guard<std::mutex> lock(m_service_map_sync);
     for(SampleMapT::const_iterator iter = m_service_map.begin(); iter != m_service_map.end(); ++iter)
     {
       // register sample
       sent_sum += RegisterSample(iter->second.service().sname(), iter->second);
-
-      // we make minimal sleeps every 10th sample to not overload
-      // registration thread
-      sent_cnt++;
-      if (sent_cnt % 10 == 0)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
     }
 
     return(sent_sum);
@@ -283,19 +272,10 @@ namespace eCAL
     if(!m_reg_topics) return(0);
 
     size_t sent_sum(0);
-    int    sent_cnt(0);
     std::lock_guard<std::mutex> lock(m_topics_map_sync);
     for(SampleMapT::const_iterator iter = m_topics_map.begin(); iter != m_topics_map.end(); ++iter)
     {
       sent_sum += RegisterSample(iter->second.topic().tname(), iter->second);
-
-      // we make minimal sleeps every 10th sample to not overload
-      // registration thread
-      sent_cnt++;
-      if (sent_cnt % 10 == 0)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      }
     }
 
     return(sent_sum);


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
There are several sleep calls in the registration logic for different entities. Because the registration is now handled by a global registration thread (with global time sync/sleep), this logic is no more needed.

**What is the new behavior?**
Removed.