### PR TITLE
Fix: Add mutex header to define missing objects

### DIFF
--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -25,7 +25,7 @@
 #include "ecal_descgate.h"
 #include <assert.h>
 #include <algorithm>
-
+#include <mutex>
 
 namespace eCAL
 {


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Set-up of bug:
* Clone project fully and load project in Qt Creator.
* Enable Parameters: `-DQT_CREATOR_SKIP_CONAN_SETUP=ON` and `-DECAL_THIRDPARTY_BUILD_PROTOBUF:BOOL=ON`.

Expected behaviour: Project compiles with no build errors.
Actual behaviour: 
```
ecal/ecal/core/src/ecal_descgate.cpp: In member function ‘void eCAL::CDescGate::ApplyDescription(const string&, const string&, const string&)’:
ecal/ecal/core/src/ecal_descgate.cpp:45:10: error: ‘unique_lock’ is not a member of ‘std’
   45 |     std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
      |          ^~~~~~~~~~~
ecal/ecal/core/src/ecal_descgate.cpp:28:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
   27 | #include <algorithm>
  +++ |+#include <mutex>
   28 | 
ecal/ecal/core/src/ecal_descgate.cpp:45:45: error: expected primary-expression before ‘>’ token
   45 |     std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
      |                                             ^
ecal/core/src/ecal_descgate.cpp:45:47: error: ‘lock’ was not declared in this scope; did you mean ‘clock’?
   45 |     std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_desc_sync);
      |                                               ^~~~
      |                                               clock
``` 


**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->

By including the missing `mutex` library header to `ecal/ecal/core/src/ecal_descgate.cpp`, the project compiles with no build errors.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

OS: Debian Sid

Very happy to co-author to merge.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
