### PR TITLE
Darkmode: Fixed Windows issues

### DIFF
--- a/app/mon/mon_gui/src/widgets/log_widget/log_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/log_widget/log_widget.cpp
@@ -92,6 +92,23 @@ LogWidget::LogWidget(QWidget *parent)
   // Pause button
   connect(ui_.pause_button, &QPushButton::toggled, this, &LogWidget::setPaused);
 
+  /*
+   * Workaround for a bug in the Qt Fusion theme that is used in Linux and
+   * Windows Dark mode by default. The Fusion theme will (at least in Qt 5.15)
+   * ignore the ON Icon. It is fixed in Qt 6.10 and up.
+   * 
+   * https://forum.qt.io/topic/129728/different-behaviour-of-icons-in-vista-style-vs-fusion-style
+   * https://codereview.qt-project.org/c/qt/qtbase/+/327734
+  */
+  connect(ui_.pause_button, &QPushButton::toggled, this,
+                      [this]()
+                      {
+                        if(ui_.pause_button->isChecked())
+                          ui_.pause_button->setIcon(QIcon(":ecalicons/START"));
+                        else
+                          ui_.pause_button->setIcon(QIcon(":ecalicons/PAUSE"));
+                      });
+
   // Clear Button
   connect(ui_.clear_button, &QPushButton::clicked, this, &LogWidget::clearLog);
 

--- a/app/mon/mon_gui/src/widgets/visualisation_widget/visualisation_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/visualisation_widget/visualisation_widget.cpp
@@ -83,6 +83,24 @@ VisualisationWidget::VisualisationWidget(const QString& topic_name, const QStrin
     ui_.tab_widget->addTab(plugin_widget->getWidget(), plugin_info.meta_data.name);
 
     connect(ui_.pause_button, &QPushButton::toggled, [plugin_widget](bool checked) { if (checked) plugin_widget->onPause(); else plugin_widget->onResume(); });
+
+    /*
+      * Workaround for a bug in the Qt Fusion theme that is used in Linux and
+      * Windows Dark mode by default. The Fusion theme will (at least in Qt 5.15)
+      * ignore the ON Icon. It is fixed in Qt 6.10 and up.
+      * 
+      * https://forum.qt.io/topic/129728/different-behaviour-of-icons-in-vista-style-vs-fusion-style
+      * https://codereview.qt-project.org/c/qt/qtbase/+/327734
+    */
+    connect(ui_.pause_button, &QPushButton::toggled, this,
+                        [this]()
+                        {
+                          if(ui_.pause_button->isChecked())
+                            ui_.pause_button->setIcon(QIcon(":ecalicons/START"));
+                          else
+                            ui_.pause_button->setIcon(QIcon(":ecalicons/PAUSE"));
+                        });
+
     connect(&update_timer_, &QTimer::timeout, [this]() {if (!isPaused()) plugin_widgets_.at(ui_.tab_widget->currentIndex())->onUpdate(); });
   }
 

--- a/app/play/play_gui/src/widgets/scenario_widget/edit_button_delegate.cpp
+++ b/app/play/play_gui/src/widgets/scenario_widget/edit_button_delegate.cpp
@@ -41,7 +41,6 @@ EditButtonDelegate::EditButtonDelegate(QAbstractItemView* parent)
   , last_time_button_hover_(false)
 {
   qApp->installEventFilter(this);
-  parent->viewport()->setAttribute( Qt::WA_Hover ); // We need to repaint the buttons when the mouse hovers over a row
 }
 
 EditButtonDelegate::~EditButtonDelegate()

--- a/app/play/play_gui/src/widgets/scenario_widget/scenario_widget.cpp
+++ b/app/play/play_gui/src/widgets/scenario_widget/scenario_widget.cpp
@@ -52,6 +52,9 @@ ScenarioWidget::ScenarioWidget(QWidget *parent)
 
   edit_button_delegate_ = new EditButtonDelegate(ui_.scenario_treeview);
   ui_.scenario_treeview->setItemDelegate(edit_button_delegate_);
+
+  ui_.scenario_treeview->viewport()->setAttribute(Qt::WA_Hover); // Set WA_Hove to display the "Edit" button on hover
+
   connect(edit_button_delegate_, &EditButtonDelegate::buttonStateChanged, scenario_tree_model_,
           [this](const QModelIndex& index)
           {
@@ -269,6 +272,18 @@ void ScenarioWidget::showEvent(QShowEvent* /*event*/)
     restoreLayout();
   }
   first_show_event_ = false;
+}
+
+void ScenarioWidget::changeEvent(QEvent* event)
+{
+  QWidget::changeEvent(event);
+
+  if (event->type() == QEvent::StyleChange)
+  {
+    // When switching to Fusion Style on Windows (mostly because of Dark mode),
+    // The hover attribute will be deactivated. So we activate it again.
+    ui_.scenario_treeview->viewport()->setAttribute(Qt::WA_Hover);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/app/play/play_gui/src/widgets/scenario_widget/scenario_widget.h
+++ b/app/play/play_gui/src/widgets/scenario_widget/scenario_widget.h
@@ -54,7 +54,8 @@ private slots:
   void openScenarioContextMenu(const QPoint& pos);
 
 protected:
-  void showEvent(QShowEvent* event) override;
+  virtual void showEvent(QShowEvent* event) override;
+  virtual void changeEvent(QEvent* event) override;
 
 private:
   Ui::ScenarioWidget ui_;

--- a/app/rec/rec_gui/src/widgets/recordermanager_widget/host_filter_delegate.cpp
+++ b/app/rec/rec_gui/src/widgets/recordermanager_widget/host_filter_delegate.cpp
@@ -31,8 +31,6 @@ HostFilterDelegate::HostFilterDelegate(QAbstractItemView* parent)
   , dialog_open_(false)
   , open_popup_(false)
 {
-  parent->viewport()->setAttribute(Qt::WA_Hover); // Important for mouse-hover events
-   
   available_hosts_model_ = new QStandardItemModel(this);
 
   QStandardItem* all_item = new QStandardItem();

--- a/app/rec/rec_gui/src/widgets/recordermanager_widget/recordermanager_widget.cpp
+++ b/app/rec/rec_gui/src/widgets/recordermanager_widget/recordermanager_widget.cpp
@@ -118,6 +118,7 @@ RecorderManagerWidget::RecorderManagerWidget(QWidget *parent)
   // Delegate for Host filter
   host_filter_delegate_ = new HostFilterDelegate(ui_.recorder_list);
   ui_.recorder_list->setItemDelegateForColumn((int)RecorderModel::Columns::HOST_FILTER, host_filter_delegate_);
+  ui_.recorder_list->viewport()->setAttribute(Qt::WA_Hover); // Important for mouse-hover events
 
   connect(QEcalRec::instance(), &QEcalRec::monitorUpdatedSignal, this,
       [this](const eCAL::rec_server::TopicInfoMap_T& /*topic_info_map*/, const eCAL::rec_server::HostsRunningEcalRec_T& hosts_running_ecal_rec)
@@ -257,6 +258,18 @@ void RecorderManagerWidget::showEvent(QShowEvent * /*event*/)
     restoreLayout();
   }
   first_show_event_ = false;
+}
+
+void RecorderManagerWidget::changeEvent(QEvent* event)
+{
+  QWidget::changeEvent(event);
+
+  if (event->type() == QEvent::StyleChange)
+  {
+    // When switching to Fusion Style on Windows (mostly because of Dark mode),
+    // The hover attribute will be deactivated. So we activate it again.
+    ui_.recorder_list->viewport()->setAttribute(Qt::WA_Hover);
+  }
 }
 
 void RecorderManagerWidget::saveLayout()

--- a/app/rec/rec_gui/src/widgets/recordermanager_widget/recordermanager_widget.h
+++ b/app/rec/rec_gui/src/widgets/recordermanager_widget/recordermanager_widget.h
@@ -46,6 +46,7 @@ public:
 ////////////////////////////////////
 protected:
   virtual void showEvent(QShowEvent *event) override;
+  virtual void changeEvent(QEvent* event) override;
 
 private:
   void saveLayout();

--- a/app/rec/rec_gui/src/widgets/recording_history_widget/recording_history_widget.cpp
+++ b/app/rec/rec_gui/src/widgets/recording_history_widget/recording_history_widget.cpp
@@ -102,6 +102,7 @@ RecordingHistoryWidget::RecordingHistoryWidget(QWidget *parent)
                                                       }
                                                 , ui_.job_history_treeview);
   ui_.job_history_treeview->setItemDelegateForColumn((int)JobHistoryModel::Columns::COMMENT, add_comment_delegate_);
+  ui_.job_history_treeview->viewport()->setAttribute(Qt::WA_Hover);
 
   // Delegate for upload button
   upload_button_delegate_ = new PushButtonDelegate(QIcon(":/ecalicons/MERGE")
@@ -320,6 +321,18 @@ void RecordingHistoryWidget::showEvent(QShowEvent* /*event*/)
     restoreLayout();
   }
   first_show_event_ = false;
+}
+
+void RecordingHistoryWidget::changeEvent(QEvent* event)
+{
+  QWidget::changeEvent(event);
+
+  if (event->type() == QEvent::StyleChange)
+  {
+    // When switching to Fusion Style on Windows (mostly because of Dark mode),
+    // The hover attribute will be deactivated. So we activate it again.
+    ui_.job_history_treeview->viewport()->setAttribute(Qt::WA_Hover);
+  }
 }
 
 void RecordingHistoryWidget::saveLayout()

--- a/app/rec/rec_gui/src/widgets/recording_history_widget/recording_history_widget.h
+++ b/app/rec/rec_gui/src/widgets/recording_history_widget/recording_history_widget.h
@@ -50,7 +50,8 @@ private:
 ////////////////////////////////////////////////
 
 protected:
-  void showEvent(QShowEvent *event) override;
+  virtual void showEvent(QShowEvent *event) override;
+  virtual void changeEvent(QEvent* event) override;
 
 private:
   void saveLayout();


### PR DESCRIPTION
Fixed the following issues:
- Mon: Play/Pause Button Icons now work properly
- Play: Fixed mouse-hover in labels-widget (i.e. the edit-buttons)
- Rec: Fixed mouse-hover in recorder and history widget (host selection and button hover)

Fixes #542 