### PR TITLE
Pinned Jinja2 to < 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ docutils==0.16 # Downgrading due to bug in docutils 0.18 https://sourceforge.net
 exhale
 idna
 imagesize
-Jinja2
+Jinja2<3.1
 lxml
 MarkupSafe
 packaging


### PR DESCRIPTION
This PR fixes a doc-compile-issue. Jinja2 removed some deprectated API with 3.1. Unfortunatelly the sphinx theme is still not properly Sphinx 4 ready, yet, so upgrading isn't the proper way in this case.