### PR TITLE
Doc: Disabled Python apidoc on macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,8 +11,17 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - name: Downgrade Python version
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
+      with:
+        setup-python: false
+        version: '5.15.2'
+        target: 'desktop'
 
     - name: Install Dependencies
       run: brew install ninja doxygen graphviz protobuf hdf5
@@ -33,12 +42,7 @@ jobs:
       with:
         submodules:  'true'
         fetch-depth: 0
-        
-    - name: Downgrade Python version
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-        
+
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
         

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -59,7 +59,7 @@ jobs:
         -DHAS_QT5=ON \
         -DHAS_CURL=ON \
         -DHAS_CAPNPROTO=ON \
-        -DBUILD_DOCS=OFF \
+        -DBUILD_DOCS=ON \
         -DBUILD_APPS=ON \
         -DBUILD_SAMPLES=ON \
         -DBUILD_TIME=ON \

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -100,13 +100,18 @@ extensions = [
 
 if is_cmake_build:
     extensions += [ \
-        'sphinx.ext.autodoc',
-        'sphinxcontrib.apidoc',
     #    'sphinxcontrib.moderncmakedomain',
         'breathe',
         'exhale',
     #    'ini-directive'
     ]
+    
+    # For some reason the apidoc crashes on macOS
+    if sys.plattform.lower() != "darwin":
+        extensions += [ \
+            'sphinx.ext.autodoc',
+            'sphinxcontrib.apidoc',
+        ]
 
 # Todo Configurations
 if is_cmake_build:

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -107,7 +107,7 @@ if is_cmake_build:
     ]
     
     # For some reason the apidoc crashes on macOS
-    if sys.plattform.lower() != "darwin":
+    if sys.platform.lower() != "darwin":
         extensions += [ \
             'sphinx.ext.autodoc',
             'sphinxcontrib.apidoc',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyGithub
 autodoc
 empy
 semantic-version 
-sphinx-tabs==3.2.0
+sphinx-tabs
 alabaster
 Babel
 beautifulsoup4
@@ -12,11 +12,11 @@ bs4
 certifi
 chardet
 colorama
-docutils==0.16 # Downgrading due to bug in docutils 0.18 https://sourceforge.net/p/docutils/bugs/431/
+docutils
 exhale
 idna
 imagesize
-Jinja2<3.1
+Jinja2
 lxml
 MarkupSafe
 packaging
@@ -27,8 +27,8 @@ requests
 six
 snowballstemmer
 soupsieve
-Sphinx==3.5.4
-sphinx-typo3-theme==4.6.2
+Sphinx
+sphinx-typo3-theme
 sphinxcontrib-apidoc
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyGithub
 autodoc
 empy
 semantic-version 
-sphinx-tabs
+sphinx-tabs==3.2.0
 alabaster
 Babel
 beautifulsoup4
@@ -12,11 +12,11 @@ bs4
 certifi
 chardet
 colorama
-docutils
+docutils==0.16 # Downgrading due to bug in docutils 0.18 https://sourceforge.net/p/docutils/bugs/431/
 exhale
 idna
 imagesize
-Jinja2
+Jinja2<3.1
 lxml
 MarkupSafe
 packaging
@@ -27,8 +27,8 @@ requests
 six
 snowballstemmer
 soupsieve
-Sphinx
-sphinx-typo3-theme
+Sphinx==3.5.4
+sphinx-typo3-theme==4.6.2
 sphinxcontrib-apidoc
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp


### PR DESCRIPTION
The python apidoc caused sphinx-build to crash on macOS.

Fixes #584