### PR TITLE
Made Qt5-msvc-code MSVC-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,10 +185,12 @@ endif()
 # --------------------------------------------------------
 # detect qt library
 # --------------------------------------------------------
-if (HAS_QT5)
-  find_package(Qt5 COMPONENTS Core QUIET)
-  if (NOT "${Qt5_FOUND}")
-    autodetect_qt5_msvc_dir()
+if(MSVC)
+  if (HAS_QT5)
+    find_package(Qt5 COMPONENTS Core QUIET)
+    if (NOT "${Qt5_FOUND}")
+      autodetect_qt5_msvc_dir()
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Before CMake would fail with not finding the MSVC Qt5 Discovery file when accidentally not having Qt5 installed