### PR TITLE
udp receiver error handling fixed

### DIFF
--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -32,8 +32,7 @@ namespace eCAL {
   {
     if (m_broadcast && m_unicast)
     {
-      std::cerr << "CUDPReceiverAsio: Setting broadcast and unicast option true is not allowed." << std::endl;
-      return;
+      throw std::runtime_error("CUDPReceiverAsio: Setting broadcast and unicast option true is not allowed.");
     }
 
     // create socket
@@ -43,8 +42,7 @@ namespace eCAL {
       m_socket.open(listen_endpoint.protocol(), ec);
       if (ec)
       {
-        std::cerr << "CUDPReceiverAsio: Unable to open socket: " << ec.message() << std::endl;
-        return;
+        throw std::runtime_error(std::string("CUDPReceiverAsio: Unable to open socket: ") + ec.message());
       }
     }
 
@@ -54,8 +52,7 @@ namespace eCAL {
       m_socket.set_option(asio::ip::udp::socket::reuse_address(true), ec);
       if (ec)
       {
-        std::cerr << "CUDPReceiverAsio: Unable to set reuse-address option: " << ec.message() << std::endl;
-        return;
+        throw std::runtime_error(std::string("CUDPReceiverAsio: Unable to set reuse-address option: ") + ec.message());
       }
     }
 
@@ -65,8 +62,7 @@ namespace eCAL {
       m_socket.bind(listen_endpoint, ec);
       if (ec)
       {
-        std::cerr << "CUDPReceiverAsio: Unable to bind socket to " << listen_endpoint.address().to_string() << ":" << listen_endpoint.port() << ": " << ec.message() << std::endl;
-        return;
+        throw std::runtime_error(std::string("CUDPReceiverAsio: Unable to bind socket to ") + listen_endpoint.address().to_string() + std::string(":") + std::to_string(listen_endpoint.port()) + std::string(": ") + ec.message());
       }
     }
 
@@ -79,7 +75,6 @@ namespace eCAL {
       if (ec)
       {
         std::cerr << "CUDPReceiverAsio: Unable to enable loopback: " << ec.message() << std::endl;
-        return;
       }
     }
 
@@ -93,7 +88,6 @@ namespace eCAL {
       if (ec)
       {
         std::cerr << "CUDPReceiverAsio: Unable to set receive buffer size: " << ec.message() << std::endl;
-        return;
       }
     }
 

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -30,8 +30,8 @@
 #pragma warning(pop)
 #endif
 
-namespace eCAL {
-
+namespace eCAL
+{
   class CUDPReceiverAsio : public CUDPReceiverBase
   {
   public:
@@ -45,6 +45,7 @@ namespace eCAL {
   protected:
     void RunIOContext(const asio::chrono::steady_clock::duration& timeout);
 
+    bool                    m_created;
     bool                    m_broadcast;
     bool                    m_unicast;
     asio::io_context        m_iocontext;

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -21,8 +21,8 @@
 namespace eCAL
 {
   ////////////////////////////////////////////////////////
-// Npcap based receiver class implementation
-////////////////////////////////////////////////////////
+  // Npcap based receiver class implementation
+  ////////////////////////////////////////////////////////
   CUDPReceiverPcap::CUDPReceiverPcap(const SReceiverAttr& attr_)
     : CUDPReceiverBase(attr_)
     , m_unicast(attr_.unicast)
@@ -30,11 +30,21 @@ namespace eCAL
     // set receive buffer size (default = 1 MB)
     int rcvbuf = 1024 * 1024;
     if (attr_.rcvbuf > 0)
+    {
       rcvbuf = attr_.rcvbuf;
-    m_socket.setReceiveBufferSize(rcvbuf);
+    }
+    if (!m_socket.setReceiveBufferSize(rcvbuf))
+    {
+      std::cerr << "CUDPReceiverPcap: Unable to set receive buffer size." << std::endl;
+      return;
+    }
 
     // bind socket
-    m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port));
+    if (!m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port)))
+    {
+      std::cerr << "CUDPReceiverPcap: Unable to bind socket." << std::endl;
+      return;
+    }
 
     if (!m_unicast)
     {
@@ -51,7 +61,11 @@ namespace eCAL
     if (!m_unicast)
     {
       // join multicast group
-      return m_socket.joinMulticastGroup(Udpcap::HostAddress(ipaddr_));
+      if (!m_socket.joinMulticastGroup(Udpcap::HostAddress(ipaddr_)))
+      {
+        std::cerr << "CUDPReceiverPcap: Unable to join multicast group." << std::endl;
+        return(false);
+      }
     }
     return(true);
   }
@@ -61,7 +75,11 @@ namespace eCAL
     if (!m_unicast)
     {
       // leave multicast group
-      return m_socket.leaveMulticastGroup(Udpcap::HostAddress(ipaddr_));
+      if (!m_socket.leaveMulticastGroup(Udpcap::HostAddress(ipaddr_)))
+      {
+        std::cerr << "CUDPReceiverPcap: Unable to leave multicast group." << std::endl;
+        return(false);
+      }
     }
     return(true);
   }

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -25,6 +25,7 @@ namespace eCAL
   ////////////////////////////////////////////////////////
   CUDPReceiverPcap::CUDPReceiverPcap(const SReceiverAttr& attr_)
     : CUDPReceiverBase(attr_)
+    , m_created(false)
     , m_unicast(attr_.unicast)
   {
     // set receive buffer size (default = 1 MB)
@@ -41,7 +42,8 @@ namespace eCAL
     // bind socket
     if (!m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port)))
     {
-      throw std::runtime_error("CUDPReceiverPcap: Unable to bind socket.");
+      std::cerr << "CUDPReceiverPcap: Unable to bind socket." << std::endl;
+      return;
     }
 
     if (!m_unicast)
@@ -52,6 +54,9 @@ namespace eCAL
 
     // join multicast group
     AddMultiCastGroup(attr_.ipaddr.c_str());
+
+    // state successful creation
+    m_created = true;
   }
 
   bool CUDPReceiverPcap::AddMultiCastGroup(const char* ipaddr_)
@@ -84,6 +89,8 @@ namespace eCAL
 
   size_t CUDPReceiverPcap::Receive(char* buf_, size_t len_, int timeout_, ::sockaddr_in* address_ /* = nullptr */)
   {
+    if (!m_created) return 0;
+
     size_t bytes_received;
     if (address_)
     {

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -36,14 +36,12 @@ namespace eCAL
     if (!m_socket.setReceiveBufferSize(rcvbuf))
     {
       std::cerr << "CUDPReceiverPcap: Unable to set receive buffer size." << std::endl;
-      return;
     }
 
     // bind socket
     if (!m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port)))
     {
-      std::cerr << "CUDPReceiverPcap: Unable to bind socket." << std::endl;
-      return;
+      throw std::runtime_error("CUDPReceiverPcap: Unable to bind socket.");
     }
 
     if (!m_unicast)

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -26,8 +26,8 @@
 #include <udpcap/npcap_helpers.h>
 #include <udpcap/udpcap_socket.h>
 
-namespace eCAL {
-
+namespace eCAL
+{
   ////////////////////////////////////////////////////////
   // Npcap based receiver class implementation
   ////////////////////////////////////////////////////////
@@ -42,6 +42,7 @@ namespace eCAL {
     size_t Receive(char* buf_, size_t len_, int timeout_, ::sockaddr_in* address_ = nullptr) override;
 
   protected:
+    bool                 m_created;
     bool                 m_unicast;
     Udpcap::UdpcapSocket m_socket;
   };


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

- [X] Bugfix


**What is the current behavior?**
Error states are not handled correctly in the udp low level receiver implementation. See this [discussion](https://github.com/continental/ecal/pull/595#discussion_r847012314).

**What is the new behavior?**
Error states are checked and functions return correctly (thanks @rhd)