### PR TITLE
Remove hostid check

### DIFF
--- a/ecal/core/include/ecal/ecal_process.h
+++ b/ecal/core/include/ecal/ecal_process.h
@@ -59,6 +59,7 @@ namespace eCAL
      *
      * @return  Host id or zero if failed.
     **/
+    [[deprecated]]
     ECAL_API int GetHostID();
 
     /**

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -28,6 +28,7 @@
 #include "ecal_register.h"
 #include "ecal_reggate.h"
 #include "ecal_globals.h"
+#include "ecal_process.h"
 
 #include <array>
 #include <chrono>
@@ -217,7 +218,6 @@ namespace eCAL
 
       sstream << "------------------------- NETWORK --------------------------------" << std::endl;
       sstream << "Host name                : " << Process::GetHostName() << std::endl;
-      sstream << "Host id                  : " << Process::GetHostID() << std::endl;
       if (eCALPAR(NET, ENABLED))
       {
         sstream << "Network mode             : cloud" << std::endl;
@@ -315,6 +315,11 @@ namespace eCAL
     }
 
     int GetHostID()
+    {
+      return __GetHostID();
+    }
+
+    int __GetHostID()
     {
       if (g_host_id == 0)
       {

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -316,29 +316,32 @@ namespace eCAL
 
     int GetHostID()
     {
-      return __GetHostID();
+      return internal::GetHostID();
     }
 
-    int __GetHostID()
+    namespace internal
     {
-      if (g_host_id == 0)
+      int GetHostID()
       {
-        // try to get unique host id
-        bool success(false);
-        int  id(0);
-        std::tie(success, id) = get_host_id();
-        if (success)
+        if (g_host_id == 0)
         {
-          g_host_id = id;
+          // try to get unique host id
+          bool success(false);
+          int  id(0);
+          std::tie(success, id) = get_host_id();
+          if (success)
+          {
+            g_host_id = id;
+          }
+          // never try again to not waste time
+          else
+          {
+            g_host_id = -1;
+            std::cerr << "Unable to get host id" << std::endl;
+          }
         }
-        // never try again to not waste time
-        else
-        {
-          g_host_id = -1;
-          std::cerr << "Unable to get host id" << std::endl;
-        }
+        return(g_host_id);
       }
-      return(g_host_id);
     }
 
     std::string GetUnitName()

--- a/ecal/core/src/ecal_process.h
+++ b/ecal/core/src/ecal_process.h
@@ -1,0 +1,40 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   ecal_process.h
+ * @brief  eCAL process interface (internal)
+**/
+
+#pragma once
+
+namespace eCAL
+{
+  namespace Process
+  {
+
+
+    /**
+     * @brief  Get unique host id.(internal version)
+     *
+     * @return  Host id or zero if failed.
+    **/
+    int __GetHostID();
+  }
+}

--- a/ecal/core/src/ecal_process.h
+++ b/ecal/core/src/ecal_process.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <ecal/ecal.h>
+
 namespace eCAL
 {
   namespace Process
@@ -35,7 +37,7 @@ namespace eCAL
        *
        * @return  Host id or zero if failed.
       **/
-      int GetHostID();
+      ECAL_API int GetHostID();
     }
   }
 }

--- a/ecal/core/src/ecal_process.h
+++ b/ecal/core/src/ecal_process.h
@@ -28,11 +28,14 @@ namespace eCAL
 {
   namespace Process
   {
-    /**
-     * @brief  Get unique host id. (internal version only)
-     *
-     * @return  Host id or zero if failed.
-    **/
-    int __GetHostID();
+    namespace internal  // non-public namespace of eCAL::Process
+    {
+      /**
+       * @brief  Get unique host id.
+       *
+       * @return  Host id or zero if failed.
+      **/
+      int GetHostID();
+    }
   }
 }

--- a/ecal/core/src/ecal_process.h
+++ b/ecal/core/src/ecal_process.h
@@ -28,10 +28,8 @@ namespace eCAL
 {
   namespace Process
   {
-
-
     /**
-     * @brief  Get unique host id.(internal version)
+     * @brief  Get unique host id. (internal version only)
      *
      * @return  Host id or zero if failed.
     **/

--- a/ecal/core/src/ecal_reggate.cpp
+++ b/ecal/core/src/ecal_reggate.cpp
@@ -270,13 +270,8 @@ namespace eCAL
 
   bool CRegGate::IsLocalHost(const eCAL::pb::Sample& ecal_sample_)
   {
-    std::string host_name = ecal_sample_.topic().hname();
-    int         host_id   = ecal_sample_.topic().hid();
+    const std::string host_name = ecal_sample_.topic().hname();
     if (host_name.empty()) return false;
-    if (host_id != 0)
-    {
-      if (host_id != Process::GetHostID()) return false;
-    }
     if (host_name != Process::GetHostName()) return false;
     return true;
   }

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -27,6 +27,8 @@
 #include <ecal/msg/protobuf/dynamic_json_subscriber.h>
 #include <ecal/ecalc.h>
 
+#include "ecal_process.h"
+
 static int CopyBuffer(void* target_, int target_len_, const std::string& source_s_)
 {
   if(target_ == nullptr) return(0);
@@ -184,7 +186,7 @@ extern "C"
 
   ECALC_API int eCAL_Process_GetHostID()
   {
-    return(eCAL::Process::GetHostID());
+    return(eCAL::Process::__GetHostID());
   }
 
   ECALC_API int eCAL_Process_GetUnitName(void* name_, int name_len_)

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -186,7 +186,7 @@ extern "C"
 
   ECALC_API int eCAL_Process_GetHostID()
   {
-    return(eCAL::Process::__GetHostID());
+    return(eCAL::Process::internal::GetHostID());
   }
 
   ECALC_API int eCAL_Process_GetUnitName(void* name_, int name_len_)

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -27,6 +27,7 @@
 #include "ecal_register.h"
 #include "ecal_descgate.h"
 #include "ecal_reader.h"
+#include "ecal_process.h"
 
 #include "readwrite/ecal_reader_udp_mc.h"
 
@@ -51,7 +52,7 @@ namespace eCAL
   ////////////////////////////////////////
   CDataReader::CDataReader() :
                  m_host_name(Process::GetHostName()),
-                 m_host_id(Process::GetHostID()),
+                 m_host_id(Process::__GetHostID()),
                  m_pid(Process::GetProcessID()),
                  m_pname(Process::GetProcessName()),
                  m_topic_name(""),

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -52,7 +52,7 @@ namespace eCAL
   ////////////////////////////////////////
   CDataReader::CDataReader() :
                  m_host_name(Process::GetHostName()),
-                 m_host_id(Process::__GetHostID()),
+                 m_host_id(Process::internal::GetHostID()),
                  m_pid(Process::GetProcessID()),
                  m_pname(Process::GetProcessName()),
                  m_topic_name(""),

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -28,6 +28,7 @@
 #include "ecal_reggate.h"
 #include "ecal_writer.h"
 #include "ecal_writer_base.h"
+#include "ecal_process.h"
 
 #include "ecal_register.h"
 #include "pubsub/ecal_pubgate.h"
@@ -61,7 +62,7 @@ namespace eCAL
 {
   CDataWriter::CDataWriter() :
     m_host_name(Process::GetHostName()),
-    m_host_id(Process::GetHostID()),
+    m_host_id(Process::__GetHostID()),
     m_pid(Process::GetProcessID()),
     m_pname(Process::GetProcessName()),
     m_topic_size(0),

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -62,7 +62,7 @@ namespace eCAL
 {
   CDataWriter::CDataWriter() :
     m_host_name(Process::GetHostName()),
-    m_host_id(Process::__GetHostID()),
+    m_host_id(Process::internal::GetHostID()),
     m_pid(Process::GetProcessID()),
     m_pname(Process::GetProcessName()),
     m_topic_size(0),


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
In order to exchange data payload via shared memory the host id has to match on the respective nodes. Unfortunately this check will lead to problems once containerized eCAL nodes (e.g. in docker) would like to communicate on shared memory, but does not have the same host id, although they are on the same host.

Issue Number: N/A

**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->
The host id check will be removed, so the nodes can already communicate via shared memory in case of a matching hostname. Furthermore the eCAL::Process::GetHostID() API function has been tagged as deprecated and can be removed completely in a future version of eCAL. In order to avoid a "deprected warning" by internal functions like CDataReader that make use of eCAL::Process::GetHostID(), the temporary function eCAL::Process::internal::GetHostID() has been introduced.

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
