### PR TITLE
Added config header to ecal.h file

### DIFF
--- a/ecal/core/include/ecal/ecal.h
+++ b/ecal/core/include/ecal/ecal.h
@@ -29,6 +29,7 @@
 #include <ecal/ecal_defs.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_client.h>
+#include <ecal/ecal_config.h>
 #include <ecal/ecal_core.h>
 #include <ecal/ecal_event.h>
 #include <ecal/ecal_log.h>


### PR DESCRIPTION
Added missing ecal/ecal_config.h to ecal/ecal.h

**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): 


**What is the current behavior?**
You have to include ecal/ecal_config.h manually in your code instead of it being provided by ecal/ecal.h

**What is the new behavior?**
You can access it view ecal/ecal.h.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

