### PR TITLE
Mon: Improved signal plotting resizability

### DIFF
--- a/app/mon/mon_plugins/signals_plotting/src/chart_widget.cpp
+++ b/app/mon/mon_plugins/signals_plotting/src/chart_widget.cpp
@@ -35,6 +35,7 @@ ChartWidget::ChartWidget(SignalPlotting::PLUGIN_STATE plugin_state, QWidget* par
 
   // Plot related logic
   qwt_plot_ = new QwtPlot(this);
+  qwt_plot_->setMinimumSize(QSize(10,10));
   qwt_plot_->setAxisTitle(QwtPlot::xBottom, QString::fromUtf8("Time / seconds"));
   qwt_plot_->setAxisScale(QwtPlot::xBottom, time_interval_.minValue(), time_interval_.maxValue());
   qwt_plot_->setAxisTitle(QwtPlot::yLeft, tab_name);
@@ -86,12 +87,12 @@ ChartWidget::ChartWidget(SignalPlotting::PLUGIN_STATE plugin_state, QWidget* par
 
   chart_settings_button_ = new QPushButton(this);
   chart_settings_button_->setText("Chart settings");
-  chart_settings_button_->setMinimumWidth(90);
+  chart_settings_button_->setMinimumWidth(10);
 
   close_button_ = new QToolButton(this);
   close_button_->setToolButtonStyle(Qt::ToolButtonStyle::ToolButtonTextOnly);
   close_button_->setText("Close");
-  close_button_->setMinimumWidth(90);
+  close_button_->setMinimumWidth(10);
   close_button_->setFixedHeight(chart_settings_button_->sizeHint().height());
 
   button_layout->addWidget(chart_settings_button_);

--- a/app/mon/mon_plugins/signals_plotting/src/plugin_widget.ui
+++ b/app/mon/mon_plugins/signals_plotting/src/plugin_widget.ui
@@ -15,62 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="button_layout">
-     <item>
-      <widget class="QPushButton" name="expand_button">
-       <property name="minimumSize">
-        <size>
-         <width>10</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Expand</string>
-       </property>
-       <property name="icon">
-        <iconset>
-         <normalon>:/ecalicons/EXPAND</normalon>
-        </iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="collapse_button">
-       <property name="minimumSize">
-        <size>
-         <width>10</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Collapse</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../../../iconset/ecalicons.qrc">
-         <normaloff>:/ecalicons/COLLAPSE</normaloff>:/ecalicons/COLLAPSE</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="button_spacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="content_layout" stretch="5,5">
-     <item>
-      <layout class="QHBoxLayout" name="logging_layout"/>
-     </item>
+    <layout class="QHBoxLayout" name="content_layout" stretch="5">
      <item>
       <widget class="QSplitter" name="splitter">
        <property name="sizePolicy">
@@ -82,26 +27,109 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <widget class="QWidget" name="treeview_widget" native="true">
-        <layout class="QHBoxLayout" name="treeview_layout">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMaximumSize</enum>
-         </property>
+       <widget class="QWidget" name="treeview_area" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
          <property name="leftMargin">
           <number>0</number>
          </property>
          <property name="topMargin">
           <number>0</number>
          </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
          <property name="bottomMargin">
           <number>0</number>
          </property>
+         <item>
+          <layout class="QHBoxLayout" name="button_layout">
+           <item>
+            <widget class="QPushButton" name="expand_button">
+             <property name="minimumSize">
+              <size>
+               <width>10</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Expand</string>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normalon>:/ecalicons/EXPAND</normalon>
+              </iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="collapse_button">
+             <property name="minimumSize">
+              <size>
+               <width>10</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Collapse</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../../../iconset/ecalicons.qrc">
+               <normaloff>:/ecalicons/COLLAPSE</normaloff>:/ecalicons/COLLAPSE</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="button_spacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="treeview_area_content">
+           <item>
+            <widget class="QWidget" name="logging_widget" native="true">
+             <layout class="QHBoxLayout" name="logging_layout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="treeview_layout"/>
+           </item>
+          </layout>
+         </item>
         </layout>
        </widget>
        <widget class="QWidget" name="plot_widget" native="true">
         <layout class="QHBoxLayout" name="widget_plot_layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
          <property name="sizeConstraint">
           <enum>QLayout::SetMaximumSize</enum>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
          </property>
          <property name="topMargin">
           <number>0</number>


### PR DESCRIPTION
1. The Graph can now make use of the area above it (previously blocked by the buttons)
    
![image](https://user-images.githubusercontent.com/11774314/166886279-7eccf782-549d-4242-8523-6c9ab256e66c.png)

2. The widget can be resized to a way smaller state (Good for moving it around). It will therefore not block resizing the GUI any more, e.g. if it is hidden behind another widget.

![image](https://user-images.githubusercontent.com/11774314/166886521-ebafc3df-9d16-4518-bd08-4dd41661c97f.png)
 