### PR TITLE
Created clang-tidy-review workflow

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,0 +1,81 @@
+name: clang-tidy-review
+
+on:
+  pull_request_target:
+    paths:
+      - '**.cpp'
+      - '**.cxx'
+      - '**.cc'
+      - '**.h'
+      - '**.hxx'
+      - '**.c'
+      - '**.hpp'
+      - '**/CMakeLists.txt'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules:  'true'
+          fetch-depth: 0
+
+      - name: Run clang-tidy
+        uses: ZedThree/clang-tidy-review@v0.8.3
+        id: review
+        with:
+          build_dir: _build
+          apt_packages: "cmake,ninja-build,build-essential,zlib1g-dev,qtbase5-dev,libhdf5-dev,libprotobuf-dev,libprotoc-dev,protobuf-compiler,libcurl4-openssl-dev,libqwt-qt5-dev"
+          config_file: ".clang-tidy"
+          exclude: "/thirdparty/*,/_build/*,convert_utf.cpp,convert_utf.h"
+          cmake_command: |
+            cmake . -B _build \
+                    -G Ninja \
+                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                    -DHAS_HDF5=ON \
+                    -DHAS_QT5=ON \
+                    -DHAS_CURL=ON \
+                    -DHAS_CAPNPROTO=OFF \
+                    -DBUILD_DOCS=OFF \
+                    -DBUILD_APPS=ON \
+                    -DBUILD_SAMPLES=ONS \
+                    -DBUILD_TIME=ON \
+                    -DBUILD_PY_BINDING=OFF \
+                    -DBUILD_STANDALONE_PY_WHEEL=OFF \
+                    -DBUILD_CSHARP_BINDING=OFF \
+                    -DBUILD_ECAL_TESTS=OFF \
+                    -DECAL_LAYER_ICEORYX=OFF \
+                    -DECAL_INCLUDE_PY_SAMPLES=OFF \
+                    -DECAL_INSTALL_SAMPLE_SOURCES=ON \
+                    -DECAL_JOIN_MULTICAST_TWICE=OFF \
+                    -DECAL_NPCAP_SUPPORT=OFF \
+                    -DECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS=ON \
+                    -DECAL_THIRDPARTY_BUILD_PROTOBUF=OFF \
+                    -DECAL_THIRDPARTY_BUILD_SPDLOG=ON \
+                    -DECAL_THIRDPARTY_BUILD_TINYXML2=ON \
+                    -DECAL_THIRDPARTY_BUILD_FINEFTP=ON \
+                    -DECAL_THIRDPARTY_BUILD_CURL=OFF \
+                    -DECAL_THIRDPARTY_BUILD_GTEST=OFF \
+                    -DECAL_THIRDPARTY_BUILD_HDF5=OFF \
+                    -DECAL_THIRDPARTY_BUILD_RECYCLE=ON \
+                    -DECAL_THIRDPARTY_BUILD_TCP_PUBSUB=ON \
+                    -DECAL_THIRDPARTY_BUILD_QWT=OFF \
+                    -DCMAKE_BUILD_TYPE=Release \
+                    -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+                    -DCMAKE_INSTALL_PREFIX=/usr \
+                    -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
+                    -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
+            cmake --build _build
+
+      - name: Passed clang-tidy checks
+        if: steps.review.outputs.total_comments > 0
+        shell: bash
+        run: |
+          echo "Clang Tidy found ${{ steps.review.outputs.total_comments }} issues"
+          exit 1


### PR DESCRIPTION
The output will be similar to this:

https://github.com/FlorianReimold/ecal/pull/11

But it will use the `.clang-tidy` file from the project root