### PR TITLE
Reintroduce functions that were removed with 5.10 (accidentially)

### DIFF
--- a/ecal/core/include/ecal/cimpl/ecal_client_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_client_cimpl.h
@@ -108,6 +108,7 @@ extern "C"
 
  /**
    * @brief Add server response callback. 
+   * @since eCAL 5.10.0
    *
    * @param handle_    Client handle. 
    * @param callback_  Callback function for server response.  
@@ -116,6 +117,18 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Client_AddResponseCallback(ECAL_HANDLE handle_, ResponseCallbackCT callback_, void* par_);
+
+  /**
+    * @deprecated Please use eCAL_Client_AddResponseCallback instead
+    * @brief Add server response callback.
+    *
+    * @param handle_    Client handle.
+    * @param callback_  Callback function for server response.
+    * @param par_       User defined context that will be forwarded to the callback function.
+    *
+    * @return  None zero if succeeded.
+   **/
+  ECALC_API_DEPRECATED int eCAL_Client_AddResponseCallbackC(ECAL_HANDLE handle_, ResponseCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove server response callback. 

--- a/ecal/core/include/ecal/cimpl/ecal_proto_dyn_json_subscriber_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_proto_dyn_json_subscriber_cimpl.h
@@ -51,6 +51,7 @@ extern "C"
 
   /**
    * @brief Add callback function for incoming receives. 
+   * @since eCAL 5.10.0
    *
    * @param handle_    Subscriber handle. 
    * @param callback_  The callback function to add.
@@ -59,6 +60,18 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Proto_Dyn_JSON_Sub_AddReceiveCallback(ECAL_HANDLE handle_, ReceiveCallbackCT callback_, void* par_);
+
+  /**
+   * @deprecated Please use eCAL_Proto_Dyn_JSON_Sub_AddReceiveCallback instead
+   * @brief Add callback function for incoming receives.
+   *
+   * @param handle_    Subscriber handle.
+   * @param callback_  The callback function to add.
+   * @param par_       User defined context that will be forwarded to the callback function.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Proto_Dyn_JSON_Sub_AddReceiveCallbackC(ECAL_HANDLE handle_, ReceiveCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove callback function for incoming receives. 

--- a/ecal/core/include/ecal/cimpl/ecal_publisher_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_publisher_cimpl.h
@@ -231,6 +231,7 @@ extern "C"
 
   /**
    * @brief Add callback function for publisher events.
+   * @since eCAL 5.10.0
    *
    * @param handle_    Publisher handle.
    * @param type_      The event type to react on.
@@ -240,6 +241,19 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Pub_AddEventCallback(ECAL_HANDLE handle_, enum eCAL_Publisher_Event type_, PubEventCallbackCT callback_, void* par_);
+
+  /**
+   * @brief Add callback function for publisher events.
+   * @deprecated Please use eCAL_Pub_AddEventCallback instead
+   *
+   * @param handle_    Publisher handle.
+   * @param type_      The event type to react on.
+   * @param callback_  The callback function to add.
+   * @param par_       User defined context that will be forwarded to the callback function.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Pub_AddEventCallbackC(ECAL_HANDLE handle_, enum eCAL_Publisher_Event type_, PubEventCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove callback function for publisher events.

--- a/ecal/core/include/ecal/cimpl/ecal_server_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_server_cimpl.h
@@ -51,6 +51,7 @@ extern "C"
 
   /**
    * @brief Add a server method callback.
+   * @since eCAL 5.10.0   
    *
    * @param handle_     Server handle.
    * @param method_     Service method name.
@@ -61,10 +62,26 @@ extern "C"
    *
    * @return  None zero if succeeded.
   **/
-  ECALC_API int eCAL_Server_AddMethodCallbackC(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void * par_);
+  ECALC_API int eCAL_Server_AddMethodCallback(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void * par_);
+
+  /**
+   * @deprecated Please use eCAL_Server_AddMethodCallback instead
+   * @brief Add a server method callback.
+   *
+   * @param handle_     Server handle.
+   * @param method_     Service method name.
+   * @param req_type_   Method request type (default = "").
+   * @param resp_type_  Method response type (default = "").
+   * @param callback_   Callback function for server request.
+   * @param par_        User defined context that will be forwarded to the request function.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Server_AddMethodCallbackC(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove a server method callback.
+   * @since eCAL 5.10.0   
    *
    * @param handle_  Server handle.
    * @param method_  Service method name.
@@ -72,6 +89,17 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Server_RemMethodCallback(ECAL_HANDLE handle_, const char* method_);
+
+  /**
+   * @deprecated Please use eCAL_Server_RemMethodCallback instead
+   * @brief Remove a server method callback.
+   *
+   * @param handle_  Server handle.
+   * @param method_  Service method name.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Server_RemMethodCallbackC(ECAL_HANDLE handle_, const char* method_);
 
   /**
    * @brief Add server event callback function.

--- a/ecal/core/include/ecal/cimpl/ecal_subscriber_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_subscriber_cimpl.h
@@ -178,6 +178,7 @@ extern "C"
 
   /**
    * @brief Add callback function for incoming receives. 
+   * @since eCAL 5.10.0
    *
    * @param handle_    Subscriber handle. 
    * @param callback_  The callback function to add.
@@ -186,6 +187,18 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Sub_AddReceiveCallback(ECAL_HANDLE handle_, ReceiveCallbackCT callback_, void* par_);
+
+  /**
+   * @brief Add callback function for incoming receives.
+   * @deprecated Please use eCAL_Sub_AddReceiveCallback instead
+   *
+   * @param handle_    Subscriber handle.
+   * @param callback_  The callback function to add.
+   * @param par_       User defined context that will be forwarded to the callback function.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Sub_AddReceiveCallbackC(ECAL_HANDLE handle_, ReceiveCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove callback function for incoming receives. 
@@ -198,6 +211,7 @@ extern "C"
 
   /**
    * @brief Add callback function for subscriber events.
+   * @since eCAL 5.10.0   
    *
    * @param handle_    Subscriber handle.
    * @param type_      The event type to react on.
@@ -207,6 +221,19 @@ extern "C"
    * @return  None zero if succeeded.
   **/
   ECALC_API int eCAL_Sub_AddEventCallback(ECAL_HANDLE handle_, enum eCAL_Subscriber_Event type_, SubEventCallbackCT callback_, void* par_);
+
+  /**
+   * @deprecated Use eCAL_Sub_AddEventCallback instead 
+   * @brief Add callback function for subscriber events.
+   *
+   * @param handle_    Subscriber handle.
+   * @param type_      The event type to react on.
+   * @param callback_  The callback function to add.
+   * @param par_       User defined context that will be forwarded to the callback function.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API_DEPRECATED int eCAL_Sub_AddEventCallbackC(ECAL_HANDLE handle_, enum eCAL_Subscriber_Event type_, SubEventCallbackCT callback_, void* par_);
 
   /**
    * @brief Remove callback function for subscriber events.

--- a/ecal/core/include/ecal/ecal_os.h
+++ b/ecal/core/include/ecal/ecal_os.h
@@ -62,3 +62,16 @@
   #define ECALC_API
   #define ECAL_API
 #endif
+
+#ifdef _MSC_VER
+  #ifdef eCAL_EXPORTS
+    #define ECALC_API_DEPRECATED __declspec(dllexport deprecated)
+  #else /* eCAL_EXPORTS */
+    #define ECALC_API_DEPRECATED __declspec(dllimport deprecated)
+  #endif /* eCAL_EXPORTS */
+#elif defined(__GNUC__) || defined(__clang__)
+  #define ECALC_API_DEPRECATED __attribute__((deprecated))
+#else
+  #pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+  #define ECALC_API_DEPRECATED
+#endif

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -679,6 +679,11 @@ extern "C"
     return(0);
   }
 
+  ECALC_API int eCAL_Pub_AddEventCallbackC(ECAL_HANDLE handle_, eCAL_Publisher_Event type_, PubEventCallbackCT callback_, void* par_)
+  {
+    return eCAL_Pub_AddEventCallback(handle_, type_, callback_, par_);
+  }
+
   ECALC_API int eCAL_Pub_RemEventCallback(ECAL_HANDLE handle_, eCAL_Publisher_Event type_)
   {
     if (handle_ == NULL) return(0);
@@ -869,6 +874,11 @@ extern "C"
     return(0);
   }
 
+  ECALC_API_DEPRECATED int eCAL_Sub_AddReceiveCallbackC(ECAL_HANDLE handle_, ReceiveCallbackCT callback_, void* par_)
+  {
+    return eCAL_Sub_AddReceiveCallback(handle_, callback_, par_);
+  }
+
   ECALC_API int eCAL_Sub_RemReceiveCallback(ECAL_HANDLE handle_)
   {
     if(handle_ == NULL) return(0);
@@ -884,6 +894,11 @@ extern "C"
     auto callback = std::bind(g_sub_event_callback, std::placeholders::_1, std::placeholders::_2, callback_, par_);
     if (sub->AddEventCallback(type_, callback)) return(1);
     return(0);
+  }
+
+  ECALC_API_DEPRECATED int eCAL_Sub_AddEventCallbackC(ECAL_HANDLE handle_, eCAL_Subscriber_Event type_, SubEventCallbackCT callback_, void* par_)
+  {
+    return eCAL_Sub_AddEventCallback(handle_, type_, callback_, par_);
   }
 
   ECALC_API int eCAL_Sub_RemEventCallback(ECAL_HANDLE handle_, eCAL_Subscriber_Event type_)
@@ -974,6 +989,11 @@ extern "C"
 
     auto callback = std::bind(g_dyn_json_sub_receive_callback, std::placeholders::_1, std::placeholders::_2, callback_, par_);
     return(sub->AddReceiveCallback(callback));
+  }
+
+  int eCAL_Proto_Dyn_JSON_Sub_AddReceiveCallbackC(ECAL_HANDLE handle_, const ReceiveCallbackCT callback_, void* par_)
+  {
+    return eCAL_Proto_Dyn_JSON_Sub_AddReceiveCallback(handle_, callback_, par_);
   }
 
   int eCAL_Proto_Dyn_JSON_Sub_RemReceiveCallback(ECAL_HANDLE handle_)
@@ -1136,7 +1156,7 @@ extern "C"
     return(1);
   }
 
-  ECALC_API int eCAL_Server_AddMethodCallbackC(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void* par_)
+  ECALC_API int eCAL_Server_AddMethodCallback(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void* par_)
   {
     if (handle_ == NULL) return(0);
     eCAL::CServiceServer* server = static_cast<eCAL::CServiceServer*>(handle_);
@@ -1144,11 +1164,21 @@ extern "C"
     return server->AddMethodCallback(method_, req_type_, resp_type_, callback);
   }
 
+  ECALC_API_DEPRECATED int eCAL_Server_AddMethodCallbackC(ECAL_HANDLE handle_, const char* method_, const char* req_type_, const char* resp_type_, MethodCallbackCT callback_, void* par_)
+  {
+    return eCAL_Server_AddMethodCallback(handle_, method_, req_type_, resp_type_, callback_, par_);
+  }
+
   ECALC_API int eCAL_Server_RemMethodCallback(ECAL_HANDLE handle_, const char* method_)
   {
     if (handle_ == NULL) return(0);
     eCAL::CServiceServer* server = static_cast<eCAL::CServiceServer*>(handle_);
     return server->RemMethodCallback(method_);
+  }
+
+  ECALC_API_DEPRECATED int eCAL_Server_RemMethodCallbackC(ECAL_HANDLE handle_, const char* method_)
+  {
+    return eCAL_Server_RemMethodCallback(handle_, method_);
   }
 
   ECALC_API int eCAL_Server_AddEventCallback(ECAL_HANDLE handle_, eCAL_Server_Event type_, ServerEventCallbackCT callback_, void* par_)
@@ -1289,6 +1319,12 @@ int eCAL_Client_AddResponseCallback(ECAL_HANDLE handle_, ResponseCallbackCT call
   auto callback = std::bind(g_response_callback, std::placeholders::_1, callback_, par_);
   return client->AddResponseCallback(callback);
 }
+
+int eCAL_Client_AddResponseCallbackC(ECAL_HANDLE handle_, ResponseCallbackCT callback_, void* par_)
+{
+  return eCAL_Client_AddResponseCallback(handle_, callback_, par_);
+}
+
 
 int eCAL_Client_RemResponseCallback(ECAL_HANDLE handle_)
 {


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [x] Other (please describe): 

Revert function renaming introduce by 17f576b

**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #671 

**What is the new behavior?**
Bring back C-Api  function that were renamed in 5.10, but mark as deprecated

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No