### PR TITLE
Set .clang-tidy file to only use clang-analyzer warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,7 @@
 #
 
 Checks: "-*,
-  clang-*
+  clang-analyzer-*
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: ''


### PR DESCRIPTION
The amount of `clang-diagnostics` is just too much at the moment to be helpful. I disabled those until we fixed them.