### PR TITLE
GH Action: changed clang-tidy-review to on pull_request

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,7 +1,7 @@
 name: clang-tidy-review
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '**.cpp'
       - '**.cxx'


### PR DESCRIPTION
It used pull_request_target before, which would always then check out master. You can check out an untrusted branch, but that is unsafe.
