### PR TITLE
Feature/measurement api clang warning

### DIFF
--- a/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
@@ -119,24 +119,29 @@ namespace eCAL
       mutable std::string data;
     };
 
+    template <typename T, typename Enable = void>
+    class IChannelType;
 
-    template <typename T>
-    class IChannel
+    template<typename T>
+    using IChannel = typename IChannelType<T>::type;
+
+    template <typename T, typename C>
+    class IBaseChannel
     {
     public:
-      IChannel(std::shared_ptr<eh5::HDF5Meas> meas_, std::string name_)
+      IBaseChannel(std::shared_ptr<eh5::HDF5Meas> meas_, std::string name_)
         : binary_channel(meas_, name_)
       {
       }
 
-      bool operator==(const IChannel& rhs) const { return  binary_channel == rhs.binary_channel; }
-      bool operator!=(const IChannel& rhs) const { return !(operator==(rhs)); }
+      bool operator==(const IBaseChannel& rhs) const { return  binary_channel == rhs.binary_channel; }
+      bool operator!=(const IBaseChannel& rhs) const { return !(operator==(rhs)); }
 
       //virtual Entry<T> operator[](unsigned long long timestamp);
       virtual Frame<T> operator[](const eh5::SEntryInfo& entry)
       {
         auto binary_entry = binary_channel[entry];
-        eCAL::message::Deserialize(binary_entry.message, message);
+        C::Deserialize(binary_entry.message, message);
         return make_frame( message, binary_entry.send_timestamp, binary_entry.receive_timestamp );
       }
 
@@ -186,7 +191,7 @@ namespace eCAL
         {
           //  return m_owner[*m_entry_iterator];
           BinaryFrame e = *it;
-          eCAL::message::Deserialize(e.message, message);
+          C::Deserialize(e.message, message);
           return make_frame(message, e.receive_timestamp, e.send_timestamp);
         };
         //friend void swap(iterator& lhs, iterator& rhs); //C++11 I think

--- a/contrib/ecalhdf5/include/ecal/measurement/proto/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/proto/imeasurement.h
@@ -1,0 +1,35 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <type_traits>
+
+#include <ecal/msg/proto/message.h>
+#include <ecal/measurement/imeasurement.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    template<typename T>
+    struct IChannelType<T, typename std::enable_if_t<std::is_base_of_v<google::protobuf::Message, T>>> { using type = IBaseChannel<T, eCAL::message::protobuf::MessageProvider>; };
+  }
+}
+

--- a/contrib/ecalhdf5/include/ecal/measurement/proto/omeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/proto/omeasurement.h
@@ -1,0 +1,33 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/msg/proto/message.h>
+#include <ecal/measurement/omeasurement.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    template<typename T>
+    struct OChannelType<T, typename std::enable_if_t<std::is_base_of_v<google::protobuf::Message, T>>> { using type = OBaseChannel<T, eCAL::message::protobuf::MessageProvider>; };
+  }
+}
+

--- a/contrib/ecalhdf5/include/ecal/measurement/string/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/string/imeasurement.h
@@ -1,0 +1,37 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <type_traits>
+
+#include <ecal/msg/string/message.h>
+#include <ecal/measurement/imeasurement.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    template<typename T>
+    struct IChannelType<T, typename std::enable_if_t<std::is_base_of_v<std::string, T>>> { using type = IBaseChannel<T, eCAL::message::string::MessageProvider>; };
+
+    using IStringChannel = IChannel<std::string>;
+  }
+}
+

--- a/contrib/ecalhdf5/include/ecal/measurement/string/omeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/string/omeasurement.h
@@ -1,0 +1,36 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <type_traits>
+
+#include <ecal/msg/string/message.h>
+#include <ecal/measurement/omeasurement.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    template<typename T>
+    struct OChannelType<T, typename std::enable_if_t<std::is_base_of_v<std::string, T>>> { using type = OBaseChannel<T, eCAL::message::string::MessageProvider>; };
+
+    using OStringChannel = OChannel<std::string>;
+  }
+}

--- a/contrib/message/include/ecal/msg/message.h
+++ b/contrib/message/include/ecal/msg/message.h
@@ -20,25 +20,27 @@
 #pragma once
 
 /*
-A type needs to implement the following functions in order that a measurement object
-can be constructed for that type (read / write)
+This class is just for convenience 
+A type which supports eCAL messages needs to implement these class functions.
+We'd rather need a contract, but that's C++20
 */
 namespace eCAL
 {
   namespace message
   {
-    //// unfortunately, we need an actual object for this :/
-    //template<typename T>
-    //std::string GetTypeName(const T& message);
-  
-    //// unfortunately, we need an actual object for this :/
-    //template<typename T>
-    //std::string GetDescription(const T& message);
-  
-    //template<typename T>
-    //bool Serialize(const T& message, std::string& buffer);
-  
-    //template<typename T>
-    //bool Deserialize(const std::string& buffer, T& message);
+    template <typename T>
+    class MessageProvider
+    {
+    public:
+      // unfortunately, we need an actual object for this :/
+      static std::string GetTypeName(const T& /*message*/);
+
+      // unfortunately, we need an actual object for this :/
+      static std::string GetDescription(const T& /*message*/);
+
+      static bool Serialize(const T& message, std::string& buffer);
+
+      static bool Deserialize(const std::string& buffer, T& message);
+    };
   }
 }

--- a/contrib/message/include/ecal/msg/proto/message.h
+++ b/contrib/message/include/ecal/msg/proto/message.h
@@ -35,26 +35,34 @@ namespace eCAL
 {
   namespace message
   {
-    // unfortunately, we need an actual object for this :/
-    inline std::string GetTypeName(const google::protobuf::Message& message)
+    namespace protobuf
     {
-      return("proto:" + message.GetTypeName());
-    }
+      class MessageProvider
+      {
+      public:
+        // unfortunately, we need an actual object for this :/
+        static std::string GetTypeName(const google::protobuf::Message& message)
+        {
+          return("proto:" + message.GetTypeName());
+        }
 
-    // unfortunately, we need an actual object for this :/
-    inline std::string GetDescription(const google::protobuf::Message& message)
-    {
-      return eCAL::protobuf::GetProtoMessageDescription(message);
-    }
+        // unfortunately, we need an actual object for this :/
+        static std::string GetDescription(const google::protobuf::Message& message)
+        {
+          return eCAL::protobuf::GetProtoMessageDescription(message);
+        }
 
-    inline bool Serialize(const google::protobuf::Message& message, std::string& buffer)
-    {
-      return message.SerializeToString(&buffer);
-    }
+        static bool Serialize(const google::protobuf::Message& message, std::string& buffer)
+        {
+          return message.SerializeToString(&buffer);
+        }
 
-    inline bool Deserialize(const std::string& buffer, google::protobuf::Message& message)
-    {
-      return message.ParseFromString(buffer);
+        static bool Deserialize(const std::string& buffer, google::protobuf::Message& message)
+        {
+          return message.ParseFromString(buffer);
+        }
+      };
+
     }
   }
 }

--- a/contrib/message/include/ecal/msg/string/message.h
+++ b/contrib/message/include/ecal/msg/string/message.h
@@ -27,28 +27,35 @@ namespace eCAL
 {
   namespace message
   {
-    // unfortunately, we need an actual object for this :/
-    inline std::string GetTypeName(const std::string& /*message*/)
+    namespace string
     {
-      return("base:std::string");
-    }
+      class MessageProvider
+      {
+      public:
+        // unfortunately, we need an actual object for this :/
+        static std::string GetTypeName(const std::string& /*message*/)
+        {
+          return("base:std::string");
+        }
 
-    // unfortunately, we need an actual object for this :/
-    inline std::string GetDescription(const std::string& /*message*/)
-    {
-      return("");
-    }
+        // unfortunately, we need an actual object for this :/
+        static std::string GetDescription(const std::string& /*message*/)
+        {
+          return("");
+        }
 
-    inline bool Serialize(const std::string& message, std::string& buffer)
-    {
-      buffer = message;
-      return true;
-    }
+        static bool Serialize(const std::string& message, std::string& buffer)
+        {
+          buffer = message;
+          return true;
+        }
 
-    inline bool Deserialize(const std::string& buffer, std::string& message)
-    {
-      message = buffer;
-      return true;
+        static bool Deserialize(const std::string& buffer, std::string& message)
+        {
+          message = buffer;
+          return true;
+        }
+      };
     }
   }
 }

--- a/samples/cpp/measurement/measurement_read/src/measurement_read.cpp
+++ b/samples/cpp/measurement/measurement_read/src/measurement_read.cpp
@@ -17,8 +17,8 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include <ecal/msg/proto/message.h>
-#include <ecal/measurement/imeasurement.h>
+#include <ecal/measurement/proto/imeasurement.h>
+#include <ecal/measurement/string/imeasurement.h>
 
 #include <iostream>
 
@@ -42,6 +42,7 @@ int main(int /*argc*/, char** /*argv*/)
 
   // create a channel (topic name "person")
   eCAL::measurement::IChannel<pb::People::Person> person_channel = meas.Get<pb::People::Person>("person");
+  eCAL::measurement::IStringChannel string_channel = meas.Get<std::string>("string");
 
   // iterate over the messages
   for (const auto& person_entry : person_channel)

--- a/samples/cpp/measurement/measurement_write/src/measurement_write.cpp
+++ b/samples/cpp/measurement/measurement_write/src/measurement_write.cpp
@@ -17,9 +17,8 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include <ecal/msg/proto/message.h>
-#include <ecal/msg/string/message.h>
-#include <ecal/measurement/omeasurement.h>
+#include <ecal/measurement/proto/omeasurement.h>
+#include <ecal/measurement/string/omeasurement.h>
 
 #include <iostream>
 
@@ -33,8 +32,8 @@ int main(int /*argc*/, char** /*argv*/)
   eCAL::measurement::OMeasurement meas(".");
 
   // create a channel (topic name "person")
-  eCAL::measurement::OChannel<pb::People::Person> person_channel = meas.Create<pb::People::Person>("person");
-  eCAL::measurement::OStringChannel string_channel = meas.Create<std::string>("string");
+  eCAL::measurement::OChannel<pb::People::Person> person_channel = meas.Create<pb::People::Person, eCAL::message::protobuf::MessageProvider>("person");
+  eCAL::measurement::OStringChannel string_channel = meas.Create<std::string, eCAL::message::string::MessageProvider>("string");
 
   pb::People::Person person;
   person.set_name("Max");


### PR DESCRIPTION
This PR intends to fix the clang warnings in imeasurement.h/omeasurement.h.

For doing this, another template parameter was introduced, but hidden from the user.

In general, the interface has not changed except for two points:
- A different file needs to be included, see 
![image](https://user-images.githubusercontent.com/49187426/169970350-473744d1-37a1-4e88-9dff-ab210f5082dd.png)
- The function signature of the `Get` function for getting a channel from a measurement now has two arguments instead of just one. Happy for any idea on how to solve this!
![image](https://user-images.githubusercontent.com/49187426/169970664-54c9ef60-f3eb-46ad-92dc-ad3247350c68.png)
- The message providers are now in the namespace  `eCAL::message::protobuf`, `eCAL::message::string`. Does it make sense to have it like this, or rather the other way round? (`eCAL::protobuf::message`, `eCAL::string::message`)....
