### PR TITLE
Actions: Restricted runs of clang-tidy actions to PR

### DIFF
--- a/.github/workflows/build-ubuntu-20.yml
+++ b/.github/workflows/build-ubuntu-20.yml
@@ -170,5 +170,6 @@ jobs:
         path: ${{ runner.workspace }}/ecal.tar.gz
 
   call-clang-tidy:
+    if: github.event_name == 'pull_request'
     needs: build-ubuntu
     uses: ./.github/workflows/run-clang-tidy.yml

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -10,7 +10,6 @@ on:
       - '**.hxx'
       - '**.c'
       - '**.hpp'
-      - '**/CMakeLists.txt'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Now we won't always have the "Base commit: 0000000000000000000000000000000000000000" error in the actions any more.