### PR TITLE
Explicitly include <cstring> for strerror() to support GCC12.

### DIFF
--- a/lib/ecal_utils/src/filesystem.cpp
+++ b/lib/ecal_utils/src/filesystem.cpp
@@ -28,6 +28,7 @@
 
   #include <ecal_utils/str_convert.h> // ANSI/Wide/UTF8 conversion
 #else // _WIN32
+  #include <cstring>    // strerror()
   #include <dirent.h>
   #include <fcntl.h>    // O_RDONLY
   #ifndef __QNXNTO__


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
The build fails with GCC 12 on Arch Linux because strerror() is not found in filesystem.cpp.

Issue Number: N/A


**What is the new behavior?**
The build passes with GCC 12 on Arch Linux because cstring is included explicitly.


**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**
This problem is also present in fineftp-server, so this pull request alone won't fix the whole problem. I also created pull request for fineftp-server in their repository and will probably ask for a version bump once that is processed.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
