### PR TITLE
Lock m_event_handle_map_sync in Destroy()

### DIFF
--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -127,17 +127,20 @@ namespace eCAL
     // do not clear the map, because we will use
     // the map keys (process id's) to recreate the
     // events in a subsequent CreateMemFile call
-    for (auto iter = m_event_handle_map.begin(); iter != m_event_handle_map.end(); ++iter)
     {
-      gCloseEvent(iter->second.event_snd);
-      gInvalidateEvent(&iter->second.event_snd);
-      if (m_timeout_ack != 0)
+      std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
+      for (auto iter = m_event_handle_map.begin(); iter != m_event_handle_map.end(); ++iter)
       {
-        gCloseEvent(iter->second.event_ack);
-        gInvalidateEvent(&iter->second.event_ack);
+        gCloseEvent(iter->second.event_snd);
+        gInvalidateEvent(&iter->second.event_snd);
+        if (m_timeout_ack != 0)
+        {
+          gCloseEvent(iter->second.event_ack);
+          gInvalidateEvent(&iter->second.event_ack);
+        }
       }
     }
-
+      
     // destroy the file
     if (!m_memfile.Destroy(true))
     {


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [x] Bugfix

The map is not locked during destroying.